### PR TITLE
Use the input/output/snippet ID for the instance names

### DIFF
--- a/api/graylog/responses.go
+++ b/api/graylog/responses.go
@@ -7,6 +7,7 @@ type ResponseCollectorConfiguration struct {
 }
 
 type ResponseCollectorInput struct {
+	Id         string            `json:"input_id"`
 	Backend    string            `json:"backend"`
 	Type       string            `json:"type"`
 	Name       string            `json:"name"`
@@ -15,6 +16,7 @@ type ResponseCollectorInput struct {
 }
 
 type ResponseCollectorOutput struct {
+	Id         string            `json:"output_id"`
 	Backend    string            `json:"backend"`
 	Type       string            `json:"type"`
 	Name       string            `json:"name"`
@@ -22,6 +24,7 @@ type ResponseCollectorOutput struct {
 }
 
 type ResponseCollectorSnippet struct {
+	Id      string `json:"snippet_id"`
 	Backend string `json:"backend"`
 	Name    string `json:"name"`
 	Value   string `json:"snippet"`

--- a/backends/nxlog/render.go
+++ b/backends/nxlog/render.go
@@ -180,25 +180,25 @@ func (nxc *NxConfig) RenderOnChange(json graylog.ResponseCollectorConfiguration)
 	for _, output := range json.Outputs {
 		if output.Backend == "nxlog" {
 			if len(output.Type) > 0 {
-				jsonConfig.Add("output-"+output.Type, output.Name, output.Properties)
+				jsonConfig.Add("output-"+output.Type, output.Id, output.Properties)
 			} else {
-				jsonConfig.Add("output", output.Name, output.Properties)
+				jsonConfig.Add("output", output.Id, output.Properties)
 			}
 		}
 	}
 	for i, input := range json.Inputs {
 		if input.Backend == "nxlog" {
 			if len(input.Type) > 0 {
-				jsonConfig.Add("input-"+input.Type, input.Name, input.Properties)
+				jsonConfig.Add("input-"+input.Type, input.Id, input.Properties)
 			} else {
-				jsonConfig.Add("input", input.Name, input.Properties)
+				jsonConfig.Add("input", input.ForwardTo, input.Properties)
 			}
-			jsonConfig.Add("route", "route-"+strconv.Itoa(i), map[string]string{"Path": input.Name + " => " + input.ForwardTo})
+			jsonConfig.Add("route", "route-"+strconv.Itoa(i), map[string]string{"Path": input.Id + " => " + input.ForwardTo})
 		}
 	}
 	for _, snippet := range json.Snippets {
 		if snippet.Backend == "nxlog" {
-			jsonConfig.Add("snippet", snippet.Name, snippet.Value)
+			jsonConfig.Add("snippet", snippet.Id, snippet.Value)
 		}
 	}
 


### PR DESCRIPTION
Fixes the config when the name contains invalid characters, like whitespace.
