### PR TITLE
Update server_url defaults for Graylog 2.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ There are a couple of configuration settings for the Sidecar:
 
 | Parameter         | Description                                                                                                                           |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| server_url        | URL to the Graylog API, e.g. `http://127.0.0.1:12900`                                                                                 |
+| server_url        | URL to the Graylog API, e.g. `http://127.0.0.1:9000/api/`                                                                             |
 | update_interval   | The interval in seconds the sidecar will fetch new configurations from the Graylog server                                             |
 | tls_skip_verify   | Ignore errors when the REST API was started with a self-signed certificate                                                            |
 | send_status       | Send the status of each backend back to Graylog and display it on the status page for the host                                        |

--- a/api/rest/rest.go
+++ b/api/rest/rest.go
@@ -34,7 +34,7 @@ import (
 var log = common.Log()
 
 const (
-	defaultBaseURL = "http://127.0.0.1:12900/"
+	defaultBaseURL = "http://127.0.0.1:9000/api/"
 	userAgent      = "Graylog Collector v" + common.CollectorVersion
 	mediaType      = "application/json"
 )

--- a/collector_sidecar.yml
+++ b/collector_sidecar.yml
@@ -1,4 +1,4 @@
-server_url: http://127.0.0.1:12900
+server_url: http://127.0.0.1:9000/api/
 update_interval: 10
 tls_skip_verify: false
 send_status: true

--- a/collector_sidecar_windows.yml
+++ b/collector_sidecar_windows.yml
@@ -1,4 +1,4 @@
-server_url: http://127.0.0.1:12900
+server_url: http://127.0.0.1:9000/api/
 update_interval: 10
 tls_skip_verify: false
 send_status: true

--- a/context/context.go
+++ b/context/context.go
@@ -49,7 +49,7 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 	// server_url
 	ctx.ServerUrl, err = url.Parse(ctx.UserConfig.ServerUrl)
 	if err != nil || ctx.ServerUrl.Scheme == "" || ctx.ServerUrl.Host == "" {
-		log.Fatal("Server-url is not valid. Should be like http://127.0.0.1:12900 ", err)
+		log.Fatal("Server-url is not valid. Should be like http://127.0.0.1:9000/api/ ", err)
 	}
 	if ctx.UserConfig.ServerUrl == "" {
 		log.Fatalf("Server-url is empty.")


### PR DESCRIPTION
The default URI for the Graylog REST API changed to http://127.0.0.1:9000/api/