### PR TITLE
Add build support for solaris/amd64 (Solaris/Illumos/OmniOS)

### DIFF
--- a/common/logger_unix.go
+++ b/common/logger_unix.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build darwin linux
+// +build darwin linux solaris
 
 package common
 

--- a/services/control_handler_unix.go
+++ b/services/control_handler_unix.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build darwin linux
+// +build darwin linux solaris
 
 package services
 


### PR DESCRIPTION
This makes the sidecar build on the solaris/amd64 platform. We **don't** provide any official support though.

Tested on omnios/r151016.