### PR TITLE
Use a shared HTTP client/transport to ensure persistent connections

### DIFF
--- a/api/graylog.go
+++ b/api/graylog.go
@@ -29,12 +29,13 @@ import (
 	"github.com/Graylog2/collector-sidecar/context"
 	"github.com/Graylog2/collector-sidecar/daemon"
 	"github.com/Graylog2/collector-sidecar/system"
+	"net/http"
 )
 
 var log = common.Log()
 
-func RequestConfiguration(context *context.Ctx) (graylog.ResponseCollectorConfiguration, error) {
-	c := rest.NewClient(nil, getTlsConfig(context))
+func RequestConfiguration(httpClient *http.Client, context *context.Ctx) (graylog.ResponseCollectorConfiguration, error) {
+	c := rest.NewClient(httpClient)
 	c.BaseURL = context.ServerUrl
 
 	params := make(map[string]string)
@@ -79,8 +80,8 @@ func RequestConfiguration(context *context.Ctx) (graylog.ResponseCollectorConfig
 	return respBody, err
 }
 
-func UpdateRegistration(context *context.Ctx, status *graylog.StatusRequest) {
-	c := rest.NewClient(nil, getTlsConfig(context))
+func UpdateRegistration(httpClient *http.Client, context *context.Ctx, status *graylog.StatusRequest) {
+	c := rest.NewClient(httpClient)
 	c.BaseURL = context.ServerUrl
 
 	metrics := &graylog.MetricsRequest{
@@ -121,7 +122,7 @@ func UpdateRegistration(context *context.Ctx, status *graylog.StatusRequest) {
 	}
 }
 
-func getTlsConfig(context *context.Ctx) *tls.Config {
+func GetTlsConfig(context *context.Ctx) *tls.Config {
 	var tlsConfig *tls.Config
 	if context.UserConfig.TlsSkipVerify {
 		tlsConfig = &tls.Config{InsecureSkipVerify: true}

--- a/api/rest/rest.go
+++ b/api/rest/rest.go
@@ -65,10 +65,9 @@ func (r *ErrorResponse) Error() string {
 		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Message)
 }
 
-func NewClient(httpClient *http.Client, tlsConfig *tls.Config) *Client {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-		httpClient.Transport = &http.Transport{
+func NewHTTPClient(tlsConfig *tls.Config) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			Dial: (&net.Dialer{
 				Timeout:   30 * time.Second,
@@ -78,7 +77,13 @@ func NewClient(httpClient *http.Client, tlsConfig *tls.Config) *Client {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			DisableCompression:    true,
-		}
+		},
+	}
+}
+
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		log.Fatal("http client must not be nil")
 	}
 
 	baseURL, _ := url.Parse(defaultBaseURL)


### PR DESCRIPTION
Previously we created a new transport connection for every HTTP request.