### PR TITLE
Make run directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,13 @@ There are a couple of configuration settings for the Sidecar:
 
 Each backend can be enabled/disabled and should point to a binary of the actual collector and a path to a configuration file the Sidecar can write to:
 
-| Parameter          | Description                                                       |
-|--------------------|-------------------------------------------------------------------|
-| name               | The type name of the collector                                    |
-| enabled            | Weather this backend should be started by the Sidecar or not      |
-| binary_path        | Path to the actual collector binary                               |
-| configuration_path | A path for this collector configuration file Sidecar can write to |
+| Parameter          | Description                                                                      |
+|--------------------|----------------------------------------------------------------------------------|
+| name               | The type name of the collector                                                   |
+| enabled            | Weather this backend should be started by the Sidecar or not                     |
+| binary_path        | Path to the actual collector binary                                              |
+| configuration_path | A path for this collector configuration file Sidecar can write to                |
+| run_path           | (NXLog only) If PidFile is changed in the default-snippet, tell Sidecar about it |
     
 ## Compile
 

--- a/backends/nxlog/nxlog.go
+++ b/backends/nxlog/nxlog.go
@@ -89,9 +89,10 @@ func (nxc *NxConfig) ValidatePreconditions() bool {
 			runDir = nxc.UserConfig.RunPath
 		}
 		if !common.IsDir(runDir) {
-			log.Errorf("[%s] Path to PidFile doesn't exist. Trying to create it before starting NXLog.")
+			log.Errorf("[%s] Path to PidFile doesn't exist. Trying to create it before starting NXLog.", nxc.Name())
 			err := common.CreatePathToFile(filepath.Join(runDir, "nxlog.run"))
 			if err != nil {
+				log.Errorf("[%s] Unable to create directory %s: %v", nxc.Name(), runDir, err)
 				return false
 			}
 		}

--- a/backends/nxlog/nxlog.go
+++ b/backends/nxlog/nxlog.go
@@ -84,8 +84,12 @@ func (nxc *NxConfig) ExecArgs() []string {
 
 func (nxc *NxConfig) ValidatePreconditions() bool {
 	if runtime.GOOS == "linux" {
-		if !common.IsDir("/var/run/graylog/collector-sidecar") {
-			err := common.CreatePathToFile("/var/run/graylog/collector-sidecar/nxlog.run")
+		runDir := "/var/run/graylog/collector-sidecar" // set in default-snippet
+		if nxc.UserConfig.RunPath != "" {
+			runDir = nxc.UserConfig.RunPath
+		}
+		if !common.IsDir(runDir) {
+			err := common.CreatePathToFile(filepath.Join(runDir, "nxlog.run"))
 			if err != nil {
 				return false
 			}

--- a/backends/nxlog/nxlog.go
+++ b/backends/nxlog/nxlog.go
@@ -89,6 +89,7 @@ func (nxc *NxConfig) ValidatePreconditions() bool {
 			runDir = nxc.UserConfig.RunPath
 		}
 		if !common.IsDir(runDir) {
+			log.Errorf("[%s] Path to PidFile doesn't exist. Trying to create it before starting NXLog.")
 			err := common.CreatePathToFile(filepath.Join(runDir, "nxlog.run"))
 			if err != nil {
 				return false

--- a/cfgfile/schema.go
+++ b/cfgfile/schema.go
@@ -39,6 +39,7 @@ type SidecarBackend struct {
 	Enabled           *bool  `config:"enabled"`
 	BinaryPath        string `config:"binary_path"`
 	ConfigurationPath string `config:"configuration_path"`
+	RunPath		  string `config:"run_path"`
 }
 
 func (sc *SidecarConfig) GetIndexByName(name string) (int, error) {

--- a/context/context.go
+++ b/context/context.go
@@ -92,6 +92,15 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 		log.Fatal("Please set the maximum age of log file rotation > 0 seconds.")
 	}
 
+	// list log files
+	if len(ctx.UserConfig.ListLogFiles) > 0 {
+		for _, dir := range ctx.UserConfig.ListLogFiles {
+			if !common.IsDir(dir) {
+				log.Fatal("Please provide a list of directories for list_log_files.")
+			}
+		}
+	}
+
 	// update_interval
 	if !(ctx.UserConfig.UpdateInterval > 0) {
 		log.Fatal("Please set update interval > 0 seconds.")


### PR DESCRIPTION
The actual configuration happens in the `default-snippet`. The Sidecar checks that the PID file directory exist and in doubt creates it. This needs to be configurable in case the `PidFile` option in the `default-snippet` is changed by the user, e.g. to run the sidecar as non-root user.
Fixes #58