### PR TITLE
Specify linux fpm platform so packages are always created properly

### DIFF
--- a/dist/recipe.rb
+++ b/dist/recipe.rb
@@ -15,6 +15,8 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   config_files '/etc/graylog/collector-sidecar/collector_sidecar.yml'
 
+  fpm_attributes rpm_os: 'linux'
+
   def build
   end
 

--- a/dist/recipe32.rb
+++ b/dist/recipe32.rb
@@ -15,6 +15,8 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   config_files '/etc/graylog/collector-sidecar/collector_sidecar.yml'
 
+  fpm_attributes rpm_os: 'linux'
+
   def build
   end
 


### PR DESCRIPTION
I noticed this when building on OSX. Without these additional configs, RPM/DEBs were built for darwin, resulting in `package collector-sidecar-0.0.9_cb1-1.x86_64 is intended for a darwin operating system` when installing the resulting RPM on Linux.

This change results in `fpm-cook` passing `--rpm-os linux` to `fpm`, see https://github.com/jordansissel/fpm/wiki:
```
    --rpm-os OS                   (rpm only) The operating system to target this rpm for. You want to set this to 'linux' if you are using fpm on OS X, for example
```

Which results in `"--target","x86_64-unknown-linux"` being passed to rpmbuild, as well as the additional logging:
```
===> [FPM] Building target platforms: x86_64-unknown-linux {}
```

The ability to pass fpm attributes in fpm-cookery was added [here](https://github.com/bernd/fpm-cookery/pull/80#issue-31232911).

Seems like explicitly specifying this doesn't hurt anything and is necessary for building on OSX (at least it was for me).