### PR TITLE
general cleanup and fix of supervisor race conditions

### DIFF
--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -16,10 +16,10 @@
 package daemon
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"syscall"
 	"time"
 
@@ -36,11 +36,12 @@ type ExecRunner struct {
 	args           []string
 	stderr, stdout string
 	isRunning      bool
+	isSupervised   bool
 	restartCount   int
 	startTime      time.Time
 	cmd            *exec.Cmd
 	service        service.Service
-	wg             sync.WaitGroup
+	signals        chan string
 }
 
 func init() {
@@ -60,10 +61,13 @@ func NewExecRunner(backend backends.Backend, context *context.Ctx) Runner {
 		args:         backend.ExecArgs(),
 		isRunning:    false,
 		restartCount: 1,
+		isSupervised: false,
+		signals:      make(chan string),
 		stderr:       filepath.Join(context.UserConfig.LogPath, backend.Name()+"_stderr.log"),
 		stdout:       filepath.Join(context.UserConfig.LogPath, backend.Name()+"_stdout.log"),
 	}
 
+	r.signalProcessor()
 	return r
 }
 
@@ -92,52 +96,84 @@ func (r *ExecRunner) ValidateBeforeStart() error {
 	if err != nil {
 		return backends.SetStatusLogErrorf(r.name, "Failed to find collector executable %q: %v", r.exec, err)
 	}
+	if r.isRunning {
+		return errors.New("Failed to start collector, it's already running")
+	}
 	return nil
 }
 
-func (r *ExecRunner) Start(s service.Service) error {
-	if err := r.ValidateBeforeStart(); err != nil {
-		log.Error(err.Error())
-		return err
+func (r *ExecRunner) StartSupervisor() {
+	if r.isSupervised == true {
+		log.Debugf("[%s] Won't start second supervisor", r.Name())
+		return
 	}
 
+	r.isSupervised = true
 	r.restartCount = 1
-	r.wg.Add(1)
 	go func() {
-		defer r.wg.Done()
 		for {
-			r.cmd = exec.Command(r.exec, r.args...)
-			r.cmd.Dir = r.daemon.Dir
-			r.cmd.Env = append(os.Environ(), r.daemon.Env...)
-			r.startTime = time.Now()
-			r.run()
+			// blocks till process exits
+			r.cmd.Wait()
 
-			// A backend should stay alive longer than 3 seconds
-			if time.Since(r.startTime) < 3*time.Second {
-				backends.SetStatusLogErrorf(r.name, "Collector exits immediately, this should not happen! Please check your collector configuration!")
+			// ignore regular shutdown
+			if !r.isRunning {
+				time.Sleep(300 * time.Millisecond)
+				continue
 			}
 			// After 60 seconds we can reset the restart counter
 			if time.Since(r.startTime) > 60*time.Second {
-				r.restartCount = 0
+				r.restartCount = 1
 			}
-			if r.restartCount <= 3 && r.isRunning {
-				log.Errorf("[%s] Backend crashed, trying to restart %d/3", r.name, r.restartCount)
-				time.Sleep(5 * time.Second)
-				r.restartCount += 1
-				continue
-				// giving up
-			} else if r.restartCount > 3 {
-				backends.SetStatusLogErrorf(r.name, "Collector failed to start after 3 tries!")
+			// don't continue to restart after 3 tries, exit supervisor and wait for a configuration update
+			if r.restartCount > 3 {
+				backends.SetStatusLogErrorf(r.name, "Unable to start collector after 3 tries, giving up!")
+				r.cmd.Wait()
+				r.isRunning = false
+				break
 			}
 
-			r.isRunning = false
-			break
+			log.Errorf("[%s] Backend crashed, trying to restart %d/3", r.name, r.restartCount)
+			r.restartCount += 1
+			r.Restart()
+
 		}
+		r.isSupervised = false
 	}()
+}
+
+func (r *ExecRunner) Start() error {
+	r.signals <- "start"
 	return nil
 }
 
-func (r *ExecRunner) Stop(s service.Service) error {
+func (r *ExecRunner) start() error {
+	if err := r.ValidateBeforeStart(); err != nil {
+		log.Errorf("[%s] %s", r.Name(), err)
+		return err
+	}
+
+	// setup process environment
+	r.cmd = exec.Command(r.exec, r.args...)
+	r.cmd.Dir = r.daemon.Dir
+	r.cmd.Env = append(os.Environ(), r.daemon.Env...)
+
+	// start the actual process and don't block
+	r.startTime = time.Now()
+	r.run()
+
+	// keep the process alive
+	r.StartSupervisor()
+	r.isRunning = true
+
+	return nil
+}
+
+func (r *ExecRunner) Stop() error {
+	r.signals <- "stop"
+	return nil
+}
+
+func (r *ExecRunner) stop() error {
 	log.Infof("[%s] Stopping", r.name)
 
 	// deactivate supervisor
@@ -154,16 +190,15 @@ func (r *ExecRunner) Stop(s service.Service) error {
 		r.cmd.Process.Kill()
 	}
 
-	// wait for background routine to finish
-	r.wg.Wait()
+	// in case the process is still running we can only wait and prevent a second process to spawn
+	r.cmd.Wait()
 
 	return nil
 }
 
-func (r *ExecRunner) Restart(s service.Service) error {
-	r.Stop(s)
-	time.Sleep(2 * time.Second)
-	r.Start(s)
+func (r *ExecRunner) Restart() error {
+	r.Stop()
+	r.Start()
 
 	return nil
 }
@@ -192,9 +227,23 @@ func (r *ExecRunner) run() {
 		r.cmd.Stdout = f
 	}
 
-	r.isRunning = true
 	r.backend.SetStatus(backends.StatusRunning, "Running")
-	r.cmd.Run()
+	err := r.cmd.Start()
+	if err != nil {
+		backends.SetStatusLogErrorf(r.name, "Failed to start collector: %s", err)
+	}
+}
 
-	return
+// process signals sequentially to prevent race conditions with the supervisor
+func (r *ExecRunner) signalProcessor () {
+	go func() {
+		for {
+			switch <- r.signals {
+			case "stop":
+				r.stop()
+			case "start":
+				r.start()
+			}
+		}
+	}()
 }

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -23,8 +23,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/kardianos/service"
-
 	"github.com/Graylog2/collector-sidecar/backends"
 	"github.com/Graylog2/collector-sidecar/common"
 	"github.com/Graylog2/collector-sidecar/context"
@@ -40,7 +38,6 @@ type ExecRunner struct {
 	restartCount   int
 	startTime      time.Time
 	cmd            *exec.Cmd
-	service        service.Service
 	signals        chan string
 }
 
@@ -81,14 +78,6 @@ func (r *ExecRunner) Running() bool {
 
 func (r *ExecRunner) SetDaemon(d *DaemonConfig) {
 	r.daemon = d
-}
-
-func (r *ExecRunner) BindToService(s service.Service) {
-	r.service = s
-}
-
-func (r *ExecRunner) GetService() service.Service {
-	return r.service
 }
 
 func (r *ExecRunner) ValidateBeforeStart() error {

--- a/daemon/runner.go
+++ b/daemon/runner.go
@@ -27,9 +27,9 @@ type Runner interface {
 	BindToService(service.Service)
 	GetService() service.Service
 	ValidateBeforeStart() error
-	Start(service.Service) error
-	Stop(service.Service) error
-	Restart(service.Service) error
+	Start() error
+	Stop() error
+	Restart() error
 	SetDaemon(*DaemonConfig)
 }
 

--- a/daemon/runner.go
+++ b/daemon/runner.go
@@ -18,14 +18,11 @@ package daemon
 import (
 	"github.com/Graylog2/collector-sidecar/backends"
 	"github.com/Graylog2/collector-sidecar/context"
-	"github.com/kardianos/service"
 )
 
 type Runner interface {
 	Name() string
 	Running() bool
-	BindToService(service.Service)
-	GetService() service.Service
 	ValidateBeforeStart() error
 	Start() error
 	Stop() error

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -24,8 +24,6 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 	"golang.org/x/sys/windows/svc/mgr"
 
-	"github.com/kardianos/service"
-
 	"github.com/Graylog2/collector-sidecar/backends"
 	"github.com/Graylog2/collector-sidecar/context"
 )
@@ -35,7 +33,6 @@ type SvcRunner struct {
 	exec        string
 	args        []string
 	startTime   time.Time
-	service     service.Service
 	serviceName string
 	isRunning   bool
 }
@@ -90,14 +87,6 @@ func (r *SvcRunner) Running() bool {
 
 func (r *SvcRunner) SetDaemon(d *DaemonConfig) {
 	r.daemon = d
-}
-
-func (r *SvcRunner) BindToService(s service.Service) {
-	r.service = s
-}
-
-func (r *SvcRunner) GetService() service.Service {
-	return r.service
 }
 
 func (r *SvcRunner) ValidateBeforeStart() error {

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -151,7 +151,7 @@ func (r *SvcRunner) ValidateBeforeStart() error {
 	return nil
 }
 
-func (r *SvcRunner) Start(s service.Service) error {
+func (r *SvcRunner) Start() error {
 	if err := r.ValidateBeforeStart(); err != nil {
 		log.Error(err.Error())
 		return err
@@ -183,7 +183,7 @@ func (r *SvcRunner) Start(s service.Service) error {
 			time.Sleep(10 * time.Second)
 			if r.isRunning && !r.Running() {
 				backends.SetStatusLogErrorf(r.name, "Backend crashed, sending restart signal")
-				r.Start(s)
+				r.Start()
 				break
 			}
 
@@ -198,7 +198,7 @@ func (r *SvcRunner) Start(s service.Service) error {
 	return err
 }
 
-func (r *SvcRunner) Stop(s service.Service) error {
+func (r *SvcRunner) Stop() error {
 	log.Infof("[%s] Stopping", r.name)
 
 	// deactivate supervisor
@@ -236,10 +236,10 @@ func (r *SvcRunner) Stop(s service.Service) error {
 	return nil
 }
 
-func (r *SvcRunner) Restart(s service.Service) error {
-	r.Stop(s)
+func (r *SvcRunner) Restart() error {
+	r.Stop()
 	time.Sleep(2 * time.Second)
-	r.Start(s)
+	r.Start()
 
 	return nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: cfb44fc1b8574f1bd844cbd539e00109972d1b41ada10f781b0f26f9f0d4bb42
-updated: 2016-09-22T14:30:53.288687642+02:00
+updated: 2016-11-22T14:18:41.72317689+01:00
 imports:
 - name: bitbucket.org/tebeka/strftime
   version: 2194253a23c090a4d5953b152a3c63fb5da4f5a4
 - name: github.com/elastic/gosigar
   version: 2716c1fe855ee5c88eae707195e0688374458c92
 - name: github.com/go-ole/go-ole
-  version: 7dfdcf409020452e29b4babcbb22f984d2aa308a
+  version: 5e9c030faf78847db7aa77e3661b9cc449de29b7
   subpackages:
   - oleutil
 - name: github.com/kardianos/osext

--- a/services/periodicals.go
+++ b/services/periodicals.go
@@ -78,10 +78,10 @@ func checkForUpdateAndRestart(httpClient *http.Client, checksum string, context 
 
 			if runner.Running() {
 				// collector was already started so a Restart will not fail
-				err = runner.Restart(runner.GetService())
+				err = runner.Restart()
 			} else {
 				// collector is not running, we do a fresh start
-				err = runner.Start(runner.GetService())
+				err = runner.Start()
 			}
 			if err != nil {
 				msg := "Failed to restart collector"


### PR DESCRIPTION
This should fix blocked collector processes during shutdown. Tests to consider:

  * Configuration update should restart a collector without creating an event for the supervisor
  * Killing a collector process should  be detected and restarted
  * After 3 retries the supervisor should stop trying
  * Shutdown of the Sidecar should not (rarely) create an supervisor event
  * Shutdown should happen pretty much in time
  * Beats 5.0.1 should be used for testing