### PR TITLE
Fix issue#116 and minor cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ BUILD_OPTS = -ldflags "-s -X github.com/Graylog2/collector-sidecar/common.GitRev
 TEST_SUITE = \
 	github.com/Graylog2/collector-sidecar/backends/nxlog \
 	github.com/Graylog2/collector-sidecar/backends/beats \
+	github.com/Graylog2/collector-sidecar/backends/beats/filebeat \
+	github.com/Graylog2/collector-sidecar/backends/beats/winlogbeat \
 	github.com/Graylog2/collector-sidecar/common
 
 all: clean misc build

--- a/backends/beats/configuration.go
+++ b/backends/beats/configuration.go
@@ -156,7 +156,7 @@ func (bc *BeatsConfig) PropertyBool(p interface{}) bool {
 }
 
 func (bc *BeatsConfig) RunMigrations(cachePath string) {
-	if bc.Version[0] == 5 && bc.Version[1] == 0 {
+	if bc.Version[0] == 5 && bc.Version[1] <= 1 {
 		// rename ssl properties
 		cp := bc.Container
 		configurationPath := []string{"output", "logstash", "tls", "certificate_key"}

--- a/backends/beats/filebeat/configuration.go
+++ b/backends/beats/filebeat/configuration.go
@@ -30,7 +30,7 @@ func NewCollectorConfig(context *context.Ctx) *FileBeatConfig {
 		Container:           map[string]interface{}{},
 		ContainerKeyMapping: map[string]string{"indexname": "index"},
 	}
-	backendIndex, err := context.UserConfig.GetIndexByName(name)
+	backendIndex, err := context.UserConfig.GetBackendIndexByName(name)
 	if err == nil {
 		bc.UserConfig = &context.UserConfig.Backends[backendIndex]
 	}

--- a/backends/beats/filebeat/render.go
+++ b/backends/beats/filebeat/render.go
@@ -182,6 +182,8 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 		}
 	}
 
+	newConfig.Beats.Version = fbc.Beats.Version // inherit beats version number, it's null at request time and not comparable
+	newConfig.Beats.RunMigrations(newConfig.CachePath())
 	if !fbc.Beats.Equals(newConfig.Beats) {
 		log.Infof("[%s] Configuration change detected, rewriting configuration file.", fbc.Name())
 		fbc.Beats.Update(newConfig.Beats)

--- a/backends/beats/filebeat/render_test.go
+++ b/backends/beats/filebeat/render_test.go
@@ -1,0 +1,66 @@
+// This file is part of Graylog.
+//
+// Graylog is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Graylog is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+
+package filebeat
+
+import (
+	"testing"
+
+	"github.com/Graylog2/collector-sidecar/context"
+	"github.com/Graylog2/collector-sidecar/api/graylog"
+	"github.com/Graylog2/collector-sidecar/cfgfile"
+)
+
+func TestFilebeatRenderTrigger(t *testing.T) {
+	context := context.NewContext()
+	context.UserConfig = &cfgfile.SidecarConfig{}
+	backendUserConfiguration := &cfgfile.SidecarBackend{Name: "filebeat"}
+	context.UserConfig.Backends = []cfgfile.SidecarBackend{*backendUserConfiguration}
+
+	engine := NewCollectorConfig(context)
+	engine.Beats.Version = []int{1, 0, 0}
+	serverResponse := graylog.ResponseCollectorConfiguration{}
+
+	triggered := engine.RenderOnChange(serverResponse)
+	if triggered != true { // initially the configuration is empty, a render call create a new configuration
+		t.Error("Initial render call did not trigger a new configuration file")
+	}
+
+	triggered = engine.RenderOnChange(serverResponse)
+	if triggered != false { // second should not be triggered, current configuration and server response are the same
+		t.Error("Second render call did trigger a new configuration. This could potentially loop forever.")
+	}
+}
+
+func TestFilebeat5RenderTrigger(t *testing.T) {
+	context := context.NewContext()
+	context.UserConfig = &cfgfile.SidecarConfig{}
+	backendUserConfiguration := &cfgfile.SidecarBackend{Name: "filebeat"}
+	context.UserConfig.Backends = []cfgfile.SidecarBackend{*backendUserConfiguration}
+
+	engine := NewCollectorConfig(context)
+	engine.Beats.Version = []int{5, 0, 0}
+	serverResponse := graylog.ResponseCollectorConfiguration{}
+
+	triggered := engine.RenderOnChange(serverResponse)
+	if triggered != true { // initially the configuration is empty, a render call create a new configuration
+		t.Error("Initial render call did not trigger a new configuration file")
+	}
+
+	triggered = engine.RenderOnChange(serverResponse)
+	if triggered != false { // second should not be triggered, current configuration and server response are the same
+		t.Error("Second render call did trigger a new configuration. This could potentially loop forever.")
+	}
+}

--- a/backends/beats/winlogbeat/configuration.go
+++ b/backends/beats/winlogbeat/configuration.go
@@ -30,7 +30,7 @@ func NewCollectorConfig(context *context.Ctx) *WinLogBeatConfig {
 		Container:           map[string]interface{}{},
 		ContainerKeyMapping: map[string]string{"indexname": "index"},
 	}
-	backendIndex, err := context.UserConfig.GetIndexByName(name)
+	backendIndex, err := context.UserConfig.GetBackendIndexByName(name)
 	if err == nil {
 		bc.UserConfig = &context.UserConfig.Backends[backendIndex]
 	}

--- a/backends/beats/winlogbeat/render.go
+++ b/backends/beats/winlogbeat/render.go
@@ -134,12 +134,13 @@ func (wlbc *WinLogBeatConfig) RenderOnChange(response graylog.ResponseCollectorC
 		}
 	}
 
-	// global fileds are available since Beats 5.0.0
+	// global fields are available since Beats 5.0.0
 	if wlbc.Beats.Version[0] >= 5 {
-		newConfig.Beats.Set(true, "fields_under_root")
 		newConfig.Beats.Set(map[string]string{"gl2_source_collector": wlbc.Beats.Context.CollectorId}, "fields")
 	}
 
+	newConfig.Beats.Version = wlbc.Beats.Version // inherit beats version number, it's null at request time and not comparable
+	newConfig.Beats.RunMigrations(newConfig.CachePath())
 	if !wlbc.Beats.Equals(newConfig.Beats) {
 		log.Infof("[%s] Configuration change detected, rewriting configuration file.", wlbc.Name())
 		wlbc.Beats.Update(newConfig.Beats)

--- a/backends/beats/winlogbeat/render_test.go
+++ b/backends/beats/winlogbeat/render_test.go
@@ -1,0 +1,66 @@
+// This file is part of Graylog.
+//
+// Graylog is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Graylog is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+
+package winlogbeat
+
+import (
+	"testing"
+
+	"github.com/Graylog2/collector-sidecar/context"
+	"github.com/Graylog2/collector-sidecar/api/graylog"
+	"github.com/Graylog2/collector-sidecar/cfgfile"
+)
+
+func TestWinlogbeatRenderTrigger(t *testing.T) {
+	context := context.NewContext()
+	context.UserConfig = &cfgfile.SidecarConfig{}
+	backendUserConfiguration := &cfgfile.SidecarBackend{Name: "winlogbeat"}
+	context.UserConfig.Backends = []cfgfile.SidecarBackend{*backendUserConfiguration}
+
+	engine := NewCollectorConfig(context)
+	engine.Beats.Version = []int{1, 0, 0}
+	serverResponse := graylog.ResponseCollectorConfiguration{}
+
+	triggered := engine.RenderOnChange(serverResponse)
+	if triggered != true { // initially the configuration is empty, a render call create a new configuration
+		t.Error("Initial render call did not trigger a new configuration file")
+	}
+
+	triggered = engine.RenderOnChange(serverResponse)
+	if triggered != false { // second should not be triggered, current configuration and server response are the same
+		t.Error("Second render call did trigger a new configuration. This could potentially loop forever.")
+	}
+}
+
+func TestWinlogbeat5RenderTrigger(t *testing.T) {
+	context := context.NewContext()
+	context.UserConfig = &cfgfile.SidecarConfig{}
+	backendUserConfiguration := &cfgfile.SidecarBackend{Name: "winlogbeat"}
+	context.UserConfig.Backends = []cfgfile.SidecarBackend{*backendUserConfiguration}
+
+	engine := NewCollectorConfig(context)
+	engine.Beats.Version = []int{5, 0, 0}
+	serverResponse := graylog.ResponseCollectorConfiguration{}
+
+	triggered := engine.RenderOnChange(serverResponse)
+	if triggered != true { // initially the configuration is empty, a render call create a new configuration
+		t.Error("Initial render call did not trigger a new configuration file")
+	}
+
+	triggered = engine.RenderOnChange(serverResponse)
+	if triggered != false { // second should not be triggered, current configuration and server response are the same
+		t.Error("Second render call did trigger a new configuration. This could potentially loop forever.")
+	}
+}

--- a/backends/nxlog/configuration.go
+++ b/backends/nxlog/configuration.go
@@ -100,7 +100,7 @@ func NewCollectorConfig(context *context.Ctx) *NxConfig {
 		Context:    context,
 		Extensions: []nxextension{{name: "gelf", properties: map[string]string{"Module": "xm_gelf"}}},
 	}
-	backendIndex, err := context.UserConfig.GetIndexByName(name)
+	backendIndex, err := context.UserConfig.GetBackendIndexByName(name)
 	if err == nil {
 		nxc.UserConfig = &context.UserConfig.Backends[backendIndex]
 		nxc.Definitions = []nxdefinition{{name: "ROOT", value: filepath.Dir(context.UserConfig.Backends[backendIndex].BinaryPath)}}

--- a/cfgfile/schema.go
+++ b/cfgfile/schema.go
@@ -43,7 +43,7 @@ type SidecarBackend struct {
 	RunPath           string `config:"run_path"`
 }
 
-func (sc *SidecarConfig) GetIndexByName(name string) (int, error) {
+func (sc *SidecarConfig) GetBackendIndexByName(name string) (int, error) {
 	index := -1
 	for i, backend := range sc.Backends {
 		if backend.Name == name {

--- a/daemon/distributor.go
+++ b/daemon/distributor.go
@@ -43,7 +43,7 @@ func (dist *Distributor) Start(s service.Service) error {
 	log.Info("Starting signal distributor")
 	dist.Running = true
 	for _, runner := range Daemon.Runner {
-		runner.Start()
+		runner.Restart()
 	}
 
 	return nil
@@ -53,7 +53,7 @@ func (dist *Distributor) Start(s service.Service) error {
 func (dist *Distributor) Stop(s service.Service) error {
 	log.Info("Stopping signal distributor")
 	for _, runner := range Daemon.Runner {
-		runner.Stop()
+		runner.Shutdown()
 	}
 	for _, runner := range Daemon.Runner {
 		for runner.Running() {time.Sleep(300 * time.Millisecond)}

--- a/daemon/runner.go
+++ b/daemon/runner.go
@@ -24,9 +24,8 @@ type Runner interface {
 	Name() string
 	Running() bool
 	ValidateBeforeStart() error
-	Start() error
-	Stop() error
 	Restart() error
+	Shutdown() error
 	SetDaemon(*DaemonConfig)
 }
 

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -140,7 +140,7 @@ func (r *SvcRunner) ValidateBeforeStart() error {
 	return nil
 }
 
-func (r *SvcRunner) Start() error {
+func (r *SvcRunner) start() error {
 	if err := r.ValidateBeforeStart(); err != nil {
 		log.Error(err.Error())
 		return err
@@ -172,7 +172,7 @@ func (r *SvcRunner) Start() error {
 			time.Sleep(10 * time.Second)
 			if r.isRunning && !r.Running() {
 				backends.SetStatusLogErrorf(r.name, "Backend crashed, sending restart signal")
-				r.Start()
+				r.start()
 				break
 			}
 
@@ -187,7 +187,7 @@ func (r *SvcRunner) Start() error {
 	return err
 }
 
-func (r *SvcRunner) Stop() error {
+func (r *SvcRunner) Shutdown() error {
 	log.Infof("[%s] Stopping", r.name)
 
 	// deactivate supervisor
@@ -226,9 +226,9 @@ func (r *SvcRunner) Stop() error {
 }
 
 func (r *SvcRunner) Restart() error {
-	r.Stop()
+	r.Shutdown()
 	time.Sleep(2 * time.Second)
-	r.Start()
+	r.start()
 
 	return nil
 }

--- a/services/periodicals.go
+++ b/services/periodicals.go
@@ -76,14 +76,7 @@ func checkForUpdateAndRestart(httpClient *http.Client, checksum string, context 
 				continue
 			}
 
-			if runner.Running() {
-				// collector was already started so a Restart will not fail
-				err = runner.Restart()
-			} else {
-				// collector is not running, we do a fresh start
-				err = runner.Start()
-			}
-			if err != nil {
+			if err := runner.Restart(); err != nil {
 				msg := "Failed to restart collector"
 				backend.SetStatus(backends.StatusError, msg)
 				log.Errorf("[%s] %s: %v", name, msg, err)


### PR DESCRIPTION
In order to solve #116 this PR is fixing the beats.Equal() function. Before comparing two configurations the migratons need to run. Otherwise two different versions of a Beat configuraton are compared and never match. The result is a restart loop. Tests are included.

While fixing this, shortcomings in the exec driver on Windows appeared. They are also part of the problem in #116. The cmd.Wait() function behaves slightly different on Linux and Windows what lead to additional restarts of a collector process during a configuration change. To work around this I am now using low-level atomic.Values for go routine synchronization. The problem is that we need to wait for a process to end in the supervisor (unexpected end) and also in the Restart() function to ensure the process is clearly finished before starting it again. (Just depending on Wait() gives odd timing issues on Windows). Neither chanels nor mutex really fit into this kind of problem. So using atomic.Values worked best for me. Tested on Linux/Windows with Graylog 2.1 and 2.2.

Addinional minor cleanups:
  * Beats 5.1 is accepted
  * Rename  GetIndexByName -> GetBackendIndexByName
  * Some debug level logging