### PR TITLE
Fix race conditions in start/stop/restart code for the exec runner

### DIFF
--- a/daemon/distributor.go
+++ b/daemon/distributor.go
@@ -43,7 +43,7 @@ func (dist *Distributor) Start(s service.Service) error {
 	log.Info("Starting signal distributor")
 	dist.Running = true
 	for _, runner := range Daemon.Runner {
-		runner.Start()
+		runner.Restart()
 	}
 
 	return nil
@@ -53,7 +53,7 @@ func (dist *Distributor) Start(s service.Service) error {
 func (dist *Distributor) Stop(s service.Service) error {
 	log.Info("Stopping signal distributor")
 	for _, runner := range Daemon.Runner {
-		runner.Stop()
+		runner.Shutdown()
 	}
 	for _, runner := range Daemon.Runner {
 		for runner.Running() {time.Sleep(300 * time.Millisecond)}

--- a/daemon/runner.go
+++ b/daemon/runner.go
@@ -24,9 +24,8 @@ type Runner interface {
 	Name() string
 	Running() bool
 	ValidateBeforeStart() error
-	Start() error
-	Stop() error
 	Restart() error
+	Shutdown() error
 	SetDaemon(*DaemonConfig)
 }
 

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -140,7 +140,7 @@ func (r *SvcRunner) ValidateBeforeStart() error {
 	return nil
 }
 
-func (r *SvcRunner) Start() error {
+func (r *SvcRunner) start() error {
 	if err := r.ValidateBeforeStart(); err != nil {
 		log.Error(err.Error())
 		return err
@@ -172,7 +172,7 @@ func (r *SvcRunner) Start() error {
 			time.Sleep(10 * time.Second)
 			if r.isRunning && !r.Running() {
 				backends.SetStatusLogErrorf(r.name, "Backend crashed, sending restart signal")
-				r.Start()
+				r.start()
 				break
 			}
 
@@ -187,7 +187,7 @@ func (r *SvcRunner) Start() error {
 	return err
 }
 
-func (r *SvcRunner) Stop() error {
+func (r *SvcRunner) Shutdown() error {
 	log.Infof("[%s] Stopping", r.name)
 
 	// deactivate supervisor
@@ -226,9 +226,9 @@ func (r *SvcRunner) Stop() error {
 }
 
 func (r *SvcRunner) Restart() error {
-	r.Stop()
+	r.Shutdown()
 	time.Sleep(2 * time.Second)
-	r.Start()
+	r.start()
 
 	return nil
 }

--- a/services/periodicals.go
+++ b/services/periodicals.go
@@ -76,14 +76,7 @@ func checkForUpdateAndRestart(httpClient *http.Client, checksum string, context 
 				continue
 			}
 
-			if runner.Running() {
-				// collector was already started so a Restart will not fail
-				err = runner.Restart()
-			} else {
-				// collector is not running, we do a fresh start
-				err = runner.Start()
-			}
-			if err != nil {
+			if err := runner.Restart(); err != nil {
 				msg := "Failed to restart collector"
 				backend.SetStatus(backends.StatusError, msg)
 				log.Errorf("[%s] %s: %v", name, msg, err)


### PR DESCRIPTION
This changes the Runner interface to only implement a Restart and Shutdown function. Using separate Start and Stop functions is prone to race conditions and would need complicated locking to avoid starting duplicate processes.