### PR TITLE
Fix Windows installer

### DIFF
--- a/dist/IfKeyExists.nsh
+++ b/dist/IfKeyExists.nsh
@@ -1,0 +1,31 @@
+!macro _IfKeyExists ROOT MAIN_KEY KEY
+  Push $R0
+  Push $R1
+ 
+  !define Index 'Line${__LINE__}'
+   
+  StrCpy $R1 "0"
+   
+  "${Index}-Loop:"
+  ; Check for Key
+  EnumRegKey $R0 ${ROOT} "${MAIN_KEY}" "$R1"
+  StrCmp $R0 "" "${Index}-False"
+  IntOp $R1 $R1 + 1
+  StrCmp $R0 "${KEY}" "${Index}-True" "${Index}-Loop"
+   
+  "${Index}-True:"
+  ;Return 1 if found
+  Push "1"
+  Goto "${Index}-End"
+   
+  "${Index}-False:"
+  ;Return 0 if not found
+  Push "0"
+  Goto "${Index}-End"
+   
+  "${Index}-End:"
+  !undef Index
+  Exch 2
+  Pop $R0
+  Pop $R1
+!macroend

--- a/dist/ReplaceInFile.nsh
+++ b/dist/ReplaceInFile.nsh
@@ -44,7 +44,8 @@ Function RIF
   RIF_leaveloop:                    ; over'n'out, Sir!
     FileClose $R1                   ; S'rry, Ma'am - clos'n now
     FileClose $R0                   ; me 2
- 
+
+    Delete "$2"                     ; go away, Sire
     Rename "$R2" "$2"               ; hi, baby!
  
     ClearErrors                     ; now i AM a newborn

--- a/dist/ReplaceInFile.nsh
+++ b/dist/ReplaceInFile.nsh
@@ -7,7 +7,7 @@
 
 Function RIF
  
-  ClearErrors  ; want to be a newborn
+  ClearErrors
  
   Exch $0      ; REPLACEMENT
   Exch
@@ -21,40 +21,40 @@ Function RIF
   Push $R3     ; a line to sar/save
   Push $R4     ; shift puffer
  
-  IfFileExists $2 +1 RIF_error      ; knock-knock
-  FileOpen $R0 $2 "r"               ; open the door
+  IfFileExists $2 +1 RIF_error
+  FileOpen $R0 $2 "r"
  
-  GetTempFileName $R2               ; who's new?
-  FileOpen $R1 $R2 "w"              ; the escape, please!
+  GetTempFileName $R2
+  FileOpen $R1 $R2 "w"
  
-  RIF_loop:                         ; round'n'round we go
+  RIF_loop:
     FileRead $R0 $R3                ; read one line
-    IfErrors RIF_leaveloop          ; enough is enough
+    IfErrors RIF_leaveloop
     RIF_sar:                        ; sar - search and replace
-      Push "$R3"                    ; (hair)stack
-      Push "$1"                     ; needle
-      Push "$0"                     ; blood
-      Call StrRep                   ; do the bartwalk
+      Push "$R3"
+      Push "$1"
+      Push "$0"
+      Call StrRep
       StrCpy $R4 "$R3"              ; remember previous state
-      Pop $R3                       ; gimme s.th. back in return!
-      StrCmp "$R3" "$R4" +1 RIF_sar ; loop, might change again!
-    FileWrite $R1 "$R3"             ; save the newbie
-  Goto RIF_loop                     ; gimme more
+      Pop $R3
+      StrCmp "$R3" "$R4" +1 RIF_sar
+    FileWrite $R1 "$R3"
+  Goto RIF_loop
  
-  RIF_leaveloop:                    ; over'n'out, Sir!
-    FileClose $R1                   ; S'rry, Ma'am - clos'n now
-    FileClose $R0                   ; me 2
+  RIF_leaveloop:
+    FileClose $R1
+    FileClose $R0
 
-    Delete "$2"                     ; go away, Sire
-    Rename "$R2" "$2"               ; hi, baby!
+    Delete "$2"                     ; delete source file, otherwise Rename will fail
+    Rename "$R2" "$2"               ; move temporary file with updated content to source file location
  
-    ClearErrors                     ; now i AM a newborn
-    Goto RIF_out                    ; out'n'away
+    ClearErrors
+    Goto RIF_out                    ; exit function
  
-  RIF_error:                        ; ups - s.th. went wrong...
-    SetErrors                       ; ...so cry, boy!
+  RIF_error:
+    SetErrors
  
-  RIF_out:                          ; your wardrobe?
+  RIF_out:
   Pop $R4
   Pop $R3
   Pop $R2

--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -113,7 +113,7 @@ Section "Install"
   File "graylog.ico"  
 
   ;Stop service to allow binary upgrade
-  !insertmacro _IfKeyExists HKLM Software\Microsoft\Windows\CurrentVersion\Uninstall GraylogCollectorSidecar
+  !insertmacro _IfKeyExists HKLM "SYSTEM\CurrentControlSet\Services" "collector-sidecar"
   Pop $R0
   ${If} $R0 = 1
     ExecWait '"$INSTDIR\graylog-collector-sidecar.exe" -service stop'

--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -16,6 +16,7 @@
   !include FileFunc.nsh
   !include WordFunc.nsh
   !include x64.nsh
+  !include IfKeyExists.nsh
 
   VIProductVersion "0.${VERSION}${VERSION_SUFFIX}"
   VIAddVersionKey "FileVersion" "${VERSION}"
@@ -111,11 +112,22 @@ Section "Install"
   File "../COPYING"
   File "graylog.ico"  
 
+  ;Stop service to allow binary upgrade
+  !insertmacro _IfKeyExists HKLM Software\Microsoft\Windows\CurrentVersion\Uninstall GraylogCollectorSidecar
+  Pop $R0
+  ${If} $R0 = 1
+    ExecWait '"$INSTDIR\graylog-collector-sidecar.exe" -service stop'
+  ${EndIf}
 
   ${If} ${RunningX64}
     File /oname=Graylog-collector-sidecar.exe "../build/${VERSION}/windows/amd64/graylog-collector-sidecar.exe"
   ${Else}
     File /oname=Graylog-collector-sidecar.exe "../build/${VERSION}/windows/386/graylog-collector-sidecar.exe"
+  ${EndIf}
+
+  ;When we stop the Sidecar service we also turn it on again
+  ${If} $R0 = 1
+    ExecWait '"$INSTDIR\graylog-collector-sidecar.exe" -service start'
   ${EndIf}
 
   WriteUninstaller "$INSTDIR\uninstall.exe"


### PR DESCRIPTION
Main issue was that the installer was not rendering the configuration template anymore. This was caused by a regression in the ReplaceInFile macro. While working on that I also fixed an issue that prevent an upgrade of the package. The installer tries to replace the binary but this is locked when the service is setup and running.