### PR TITLE
Add NodeID to context so that it may be shipped

### DIFF
--- a/backends/beats/filebeat/render.go
+++ b/backends/beats/filebeat/render.go
@@ -113,9 +113,9 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 			prospector = append(prospector, make(map[string]interface{}))
 			idx := len(prospector) - 1
 
-			// add gl2_source_collector and gl2_source_node_id unconditionally
+			// add gl2_source_collector and source_node_id unconditionally
 			prospector[idx]["fields"] = map[string]interface{}{"gl2_source_collector": fbc.Beats.Context.CollectorId}
-                        prospector[idx]["fields"] = map[string]interface{}{"gl2_source_node_id": fbc.Beats.Context.NodeId}
+                        prospector[idx]["fields"] = map[string]interface{}{"source_node_id": fbc.Beats.Context.NodeId}
 			// we dont support stdin input type
 			prospector[idx]["input_type"] = "log"
 			for property, value := range input.Properties {

--- a/backends/beats/filebeat/render.go
+++ b/backends/beats/filebeat/render.go
@@ -113,8 +113,9 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 			prospector = append(prospector, make(map[string]interface{}))
 			idx := len(prospector) - 1
 
-			// add gl2_source_collector unconditionally
+			// add gl2_source_collector and gl2_source_node_id unconditionally
 			prospector[idx]["fields"] = map[string]interface{}{"gl2_source_collector": fbc.Beats.Context.CollectorId}
+                        prospector[idx]["fields"] = map[string]interface{}{"gl2_source_node_id": fbc.Beats.Context.NodeId}
 			// we dont support stdin input type
 			prospector[idx]["input_type"] = "log"
 			for property, value := range input.Properties {

--- a/backends/beats/winlogbeat/render.go
+++ b/backends/beats/winlogbeat/render.go
@@ -137,6 +137,7 @@ func (wlbc *WinLogBeatConfig) RenderOnChange(response graylog.ResponseCollectorC
 	// global fields are available since Beats 5.0.0
 	if wlbc.Beats.Version[0] >= 5 {
 		newConfig.Beats.Set(map[string]string{"gl2_source_collector": wlbc.Beats.Context.CollectorId}, "fields")
+		newConfig.Beats.Set(map[string]string{"source_node_id": wlbc.Beats.Context.NodeId}, "fields")
 	}
 
 	newConfig.Beats.Version = wlbc.Beats.Version // inherit beats version number, it's null at request time and not comparable

--- a/backends/nxlog/render.go
+++ b/backends/nxlog/render.go
@@ -263,6 +263,7 @@ func (nxc *NxConfig) gelfUdpOutputsToString() string {
 			result.WriteString("	OutputType  GELF\n")
 			result.WriteString("	Exec $short_message = $raw_event; # Avoids truncation of the short_message field.\n")
 			result.WriteString("	Exec $gl2_source_collector = '" + nxc.Context.CollectorId + "';\n")
+			result.WriteString("    Exec $gl2_source_node_id = '" + nxc.Context.NodeId + "';\n")
 			if nxc.isDisabled(can.properties["override_hostname"]) {
 				result.WriteString("	Exec $Hostname = hostname_fqdn();\n")
 			}
@@ -293,6 +294,7 @@ func (nxc *NxConfig) gelfTcpOutputsToString() string {
 			result.WriteString("	OutputType  GELF_TCP\n")
 			result.WriteString("	Exec $short_message = $raw_event; # Avoids truncation of the short_message field.\n")
 			result.WriteString("	Exec $gl2_source_collector = '" + nxc.Context.CollectorId + "';\n")
+			result.WriteString("    Exec $gl2_source_node_id = '" + nxc.Context.NodeId + "';\n")
 			if nxc.isDisabled(can.properties["override_hostname"]) {
 				result.WriteString("	Exec $Hostname = hostname_fqdn();\n")
 			}
@@ -335,6 +337,7 @@ func (nxc *NxConfig) gelfTcpTlsOutputsToString() string {
 			}
 			result.WriteString("	Exec $short_message = $raw_event; # Avoids truncation of the short_message field.\n")
 			result.WriteString("	Exec $gl2_source_collector = '" + nxc.Context.CollectorId + "';\n")
+			result.WriteString("    Exec $gl2_source_node_id = '" + nxc.Context.NodeId + "';\n")
 			if nxc.isDisabled(can.properties["override_hostname"]) {
 				result.WriteString("	Exec $Hostname = hostname_fqdn();\n")
 			}

--- a/backends/nxlog/render.go
+++ b/backends/nxlog/render.go
@@ -263,7 +263,7 @@ func (nxc *NxConfig) gelfUdpOutputsToString() string {
 			result.WriteString("	OutputType  GELF\n")
 			result.WriteString("	Exec $short_message = $raw_event; # Avoids truncation of the short_message field.\n")
 			result.WriteString("	Exec $gl2_source_collector = '" + nxc.Context.CollectorId + "';\n")
-			result.WriteString("    Exec $gl2_source_node_id = '" + nxc.Context.NodeId + "';\n")
+			result.WriteString("    Exec $source_node_id = '" + nxc.Context.NodeId + "';\n")
 			if nxc.isDisabled(can.properties["override_hostname"]) {
 				result.WriteString("	Exec $Hostname = hostname_fqdn();\n")
 			}
@@ -294,7 +294,7 @@ func (nxc *NxConfig) gelfTcpOutputsToString() string {
 			result.WriteString("	OutputType  GELF_TCP\n")
 			result.WriteString("	Exec $short_message = $raw_event; # Avoids truncation of the short_message field.\n")
 			result.WriteString("	Exec $gl2_source_collector = '" + nxc.Context.CollectorId + "';\n")
-			result.WriteString("    Exec $gl2_source_node_id = '" + nxc.Context.NodeId + "';\n")
+			result.WriteString("    Exec $source_node_id = '" + nxc.Context.NodeId + "';\n")
 			if nxc.isDisabled(can.properties["override_hostname"]) {
 				result.WriteString("	Exec $Hostname = hostname_fqdn();\n")
 			}
@@ -337,7 +337,7 @@ func (nxc *NxConfig) gelfTcpTlsOutputsToString() string {
 			}
 			result.WriteString("	Exec $short_message = $raw_event; # Avoids truncation of the short_message field.\n")
 			result.WriteString("	Exec $gl2_source_collector = '" + nxc.Context.CollectorId + "';\n")
-			result.WriteString("    Exec $gl2_source_node_id = '" + nxc.Context.NodeId + "';\n")
+			result.WriteString("    Exec $source_node_id = '" + nxc.Context.NodeId + "';\n")
 			if nxc.isDisabled(can.properties["override_hostname"]) {
 				result.WriteString("	Exec $Hostname = hostname_fqdn();\n")
 			}

--- a/context/context.go
+++ b/context/context.go
@@ -33,6 +33,7 @@ var log = logger.Log()
 type Ctx struct {
 	ServerUrl   *url.URL
 	CollectorId string
+        NodeId      string
 	UserConfig  *cfgfile.SidecarConfig
 	Inventory   *system.Inventory
 }
@@ -73,6 +74,7 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 			log.Fatal("No node-id configured and not able to obtain hostname as alternative.")
 		}
 	}
+        ctx.NodeId = ctx.UserConfig.NodeId
 
 	// tags
 	if len(ctx.UserConfig.Tags) == 0 {


### PR DESCRIPTION
One thing I've found pretty useful in my own environment is to be able to ship the nodeid (which, in our case, has a bit more context than a hostname such as the machine's role) to Graylog. This PR adds that functionality to filebeat and nxlog backends.

Feedback welcome; this worked for me but I might be missing some edge cases or other information?