### PR TITLE
Beats 5.5 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ build-solaris: solaris-sigar-patch ## Build collector-sidecar binary for Solaris
 
 build-linux32: ## Build collector-sidecar binary for Linux 32bit
 	@mkdir -p build/$(COLLECTOR_VERSION)/linux/386
-	GOOS=linux GOARCH=386 $(GO) build $(BUILD_OPTS) -v -i -o build/$(COLLECTOR_VERSION)/linux/386/graylog-collector-sidecar
+	GOOS=linux GOARCH=386 $(GO) build $(BUILD_OPTS) -pkgdir $(GOPATH)/go_linux32  -v -i -o build/$(COLLECTOR_VERSION)/linux/386/graylog-collector-sidecar
 
 build-darwin: ## Build collector-sidecar binary for OSX
 	@mkdir -p build/$(COLLECTOR_VERSION)/darwin/amd64
@@ -87,11 +87,11 @@ build-freebsd:
 
 build-windows: ## Build collector-sidecar binary for Windows
 	@mkdir -p build/$(COLLECTOR_VERSION)/windows/amd64
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc $(GO) build $(BUILD_OPTS) -pkgdir $(HOME)/.go_win -v -i -o build/$(COLLECTOR_VERSION)/windows/amd64/graylog-collector-sidecar.exe
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc $(GO) build $(BUILD_OPTS) -pkgdir $(GOPATH)/go_win -v -i -o build/$(COLLECTOR_VERSION)/windows/amd64/graylog-collector-sidecar.exe
 
 build-windows32: ## Build collector-sidecar binary for Windows 32bit
 	@mkdir -p build/$(COLLECTOR_VERSION)/windows/386
-	GOOS=windows GOARCH=386 CGO_ENABLED=1 CC=i686-w64-mingw32-gcc $(GO) build $(BUILD_OPTS) -pkgdir $(HOME)/.go_win32 -v -i -o build/$(COLLECTOR_VERSION)/windows/386/graylog-collector-sidecar.exe
+	GOOS=windows GOARCH=386 CGO_ENABLED=1 CC=i686-w64-mingw32-gcc $(GO) build $(BUILD_OPTS) -pkgdir $(GOPATH)/go_win32 -v -i -o build/$(COLLECTOR_VERSION)/windows/386/graylog-collector-sidecar.exe
 
 package-all: prepare-package package-linux package-linux32 package-windows package-tar
 

--- a/dist/fetch_collectors.sh
+++ b/dist/fetch_collectors.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ARCHS=( x86 x86_64 )
-FILEBEAT_VERSION=5.4.2
-WINLOGBEAT_VERSION=5.4.2
+FILEBEAT_VERSION=5.5.1
+WINLOGBEAT_VERSION=5.5.1
 
 # $1: beat name
 # $2: beat operating system


### PR DESCRIPTION
This adds Beats 5.5 support. Configuration changes are based on the release notes: https://www.elastic.co/guide/en/beats/libbeat/5.5/release-notes-5.5.0.html

Additionally a small fix in the Makefile is done to respect other GOPATHs than HOME/.go