### PR TITLE
Implementation of allowed paths configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,21 +166,21 @@ Run the Sidecar in foreground mode for debugging purposes. Simply call it like t
 
 There are a couple of configuration settings for the Sidecar:
 
-| Parameter         | Description                                                                                                                           |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| server_url        | URL to the Graylog API, e.g. `http://127.0.0.1:9000/api/`                                                                             |
-| update_interval   | The interval in seconds the sidecar will fetch new configurations from the Graylog server                                             |
-| tls_skip_verify   | Ignore errors when the REST API was started with a self-signed certificate                                                            |
-| send_status       | Send the status of each backend back to Graylog and display it on the status page for the host                                        |
-| list_log_files    | Send a directory listing to Graylog and display it on the host status page. This can also be a list of directories                    |
-| node_id           | Name of the Sidecar instance, will also show up in the web interface                                                                  |
-| collector_id      | Unique ID (UUID) of the instance. This can be an ID string or a path to an ID file                                                    |
-| log_path          | A path to a directory where the Sidecar can store the output of each running collector backend                                        |
-| log_rotation_time | Rotate the stdout and stderr logs of each collector after X seconds                                                                   |
-| log_max_age       | Delete rotated log files older than Y seconds                                                                                         |
-| tags              | List of configuration tags. All configurations on the server side that match the tag list will be fetched and merged by this instance |
-| backends          | A list of collector backends the user wants to run on the target host                                                                 |
-| allowed_paths     | List of paths allowed for log collection. The paths are regex's that are matched against path globs received from Graylog server      |
+| Parameter         | Description                                                                                                                               |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| server_url        | URL to the Graylog API, e.g. `http://127.0.0.1:9000/api/`                                                                                 |
+| update_interval   | The interval in seconds the sidecar will fetch new configurations from the Graylog server                                                 |
+| tls_skip_verify   | Ignore errors when the REST API was started with a self-signed certificate                                                                |
+| send_status       | Send the status of each backend back to Graylog and display it on the status page for the host                                            |
+| list_log_files    | Send a directory listing to Graylog and display it on the host status page. This can also be a list of directories                        |
+| node_id           | Name of the Sidecar instance, will also show up in the web interface                                                                      |
+| collector_id      | Unique ID (UUID) of the instance. This can be an ID string or a path to an ID file                                                        |
+| log_path          | A path to a directory where the Sidecar can store the output of each running collector backend                                            |
+| log_rotation_time | Rotate the stdout and stderr logs of each collector after X seconds                                                                       |
+| log_max_age       | Delete rotated log files older than Y seconds                                                                                             |
+| tags              | List of configuration tags. All configurations on the server side that match the tag list will be fetched and merged by this instance     |
+| backends          | A list of collector backends the user wants to run on the target host                                                                     |
+| allowed_paths     | Optional list of paths allowed for log collection. The paths are regex's that are matched against path globs received from Graylog server |
 
 Each backend can be enabled/disabled and should point to a binary of the actual collector and a path to a configuration file the Sidecar can write to:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Install the NXLog package from the offical download [page](https://nxlog.org/pro
   $ sudo /etc/init.d/nxlog stop
   $ sudo update-rc.d -f nxlog remove
   $ sudo gpasswd -a nxlog adm
- 
+
   $ sudo dpkg -i collector-sidecar_0.1.4-1_amd64.deb
   $ sudo chown -R nxlog.nxlog /var/spool/collector-sidecar/nxlog
 ```
@@ -180,6 +180,7 @@ There are a couple of configuration settings for the Sidecar:
 | log_max_age       | Delete rotated log files older than Y seconds                                                                                         |
 | tags              | List of configuration tags. All configurations on the server side that match the tag list will be fetched and merged by this instance |
 | backends          | A list of collector backends the user wants to run on the target host                                                                 |
+| allowed_paths     | List of paths allowed for log collection. The paths are matched against path globs received from Graylog server                       |
 
 Each backend can be enabled/disabled and should point to a binary of the actual collector and a path to a configuration file the Sidecar can write to:
 
@@ -190,7 +191,7 @@ Each backend can be enabled/disabled and should point to a binary of the actual 
 | binary_path        | Path to the actual collector binary                                              |
 | configuration_path | A path for this collector configuration file Sidecar can write to                |
 | run_path           | (NXLog only) If PidFile is changed in the default-snippet, tell Sidecar about it |
-    
+
 ## Compile
 
   * Clone the repository into your `$GOPATH` under `src/github.com/Graylog2/collector-sidecar`

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ There are a couple of configuration settings for the Sidecar:
 | log_max_age       | Delete rotated log files older than Y seconds                                                                                         |
 | tags              | List of configuration tags. All configurations on the server side that match the tag list will be fetched and merged by this instance |
 | backends          | A list of collector backends the user wants to run on the target host                                                                 |
-| allowed_paths     | List of paths allowed for log collection. The paths are matched against path globs received from Graylog server                       |
+| allowed_paths     | List of paths allowed for log collection. The paths are regex's that are matched against path globs received from Graylog server      |
 
 Each backend can be enabled/disabled and should point to a binary of the actual collector and a path to a configuration file the Sidecar can write to:
 

--- a/backends/beats/filebeat/allowedpaths.go
+++ b/backends/beats/filebeat/allowedpaths.go
@@ -1,34 +1,40 @@
 package filebeat
 
 import (
-  "strings"
+  "regexp"
 )
 
 // Removes prospectors from filebeat configuration that have paths that do not match list of allowed paths.
 // Removed prospectors are logged as warnings to supplied logger.
-func PruneDisallowedProspectors(config map[string]interface{}, allowedPaths []string) {
-  log.Debugf("Allowed paths is %s.", allowedPaths)
-  newProspectors := make([]interface{}, 0)
+func PruneDisallowedProspectors(config map[string]interface{}, allowedPaths []string) bool {
   if prospectors, ok := getProspectors(config).([]map[string]interface{}); ok {
+    acceptedProspectors := make([]interface{}, 0)
     for target, prospector := range prospectors {
       log.Debugf("Checking prospector [%s] configuration for allowed paths.", prospector)
       // Check that all paths of prospector are allowed
-      var allowed bool = true
-      for _, path := range prospector["paths"].([]interface{}) {
-        if !isPathAllowed(path.(string), allowedPaths) {
-          log.Warnf("Prospector %s is not allowed due to local path restriction for [%s].\n", prospectors[target], path)
-          allowed = false
-          break
+      if paths, ok := prospector["paths"].([]interface{}); ok {
+        var allowed bool = true
+        for _, path := range paths {
+          if !isPathAllowed(path.(string), allowedPaths) {
+            log.Warnf("Prospector %s is not allowed due to local path restriction for [%s].\n", prospectors[target], path)
+            allowed = false
+            break
+          }
         }
-      }
-      if allowed {
-        newProspectors = append(newProspectors, prospector)
+        if allowed {
+          acceptedProspectors = append(acceptedProspectors, prospector)
+        }
+      } else {
+        log.Warnf("Could not locate paths for prospector.")
+        return false
       }
     }
 
-    setProspectors(config, newProspectors)
+    setProspectors(config, acceptedProspectors)
+    return true
   } else {
     log.Warnf("Could not locate prospectors configuration.")
+    return false
   }
 }
 
@@ -38,7 +44,8 @@ func isPathAllowed(path string, allowedPaths []string) bool {
     return true
   }
   for _, allowedPath := range allowedPaths {
-    if strings.HasPrefix(path, allowedPath) {
+    match, _ := regexp.MatchString(allowedPath, path)
+    if (match) {
       return true
     }
   }
@@ -62,6 +69,9 @@ func getElement(config interface{}, path ...string) interface{} {
   for target := 0; target < len(path); target++ {
 		if mmap, ok := object.(map[string]interface{}); ok {
       object = mmap[path[target]]
+    } else {
+      log.Warnf("Unable to retrieve element %s from configuration - parent is not a map[string].", path[target])
+      return nil
     }
 	}
 	return object

--- a/backends/beats/filebeat/allowedpaths.go
+++ b/backends/beats/filebeat/allowedpaths.go
@@ -1,0 +1,68 @@
+package filebeat
+
+import (
+  "strings"
+)
+
+// Removes prospectors from filebeat configuration that have paths that do not match list of allowed paths.
+// Removed prospectors are logged as warnings to supplied logger.
+func PruneDisallowedProspectors(config map[string]interface{}, allowedPaths []string) {
+  log.Debugf("Allowed paths is %s.", allowedPaths)
+  newProspectors := make([]interface{}, 0)
+  if prospectors, ok := getProspectors(config).([]map[string]interface{}); ok {
+    for target, prospector := range prospectors {
+      log.Debugf("Checking prospector [%s] configuration for allowed paths.", prospector)
+      // Check that all paths of prospector are allowed
+      var allowed bool = true
+      for _, path := range prospector["paths"].([]interface{}) {
+        if !isPathAllowed(path.(string), allowedPaths) {
+          log.Warnf("Prospector %s is not allowed due to local path restriction for [%s].\n", prospectors[target], path)
+          allowed = false
+          break
+        }
+      }
+      if allowed {
+        newProspectors = append(newProspectors, prospector)
+      }
+    }
+
+    setProspectors(config, newProspectors)
+  } else {
+    log.Warnf("Could not locate prospectors configuration.")
+  }
+}
+
+// Checks if given path is found in given list of allowed paths
+func isPathAllowed(path string, allowedPaths []string) bool {
+  if allowedPaths == nil || len(allowedPaths) == 0 {
+    return true
+  }
+  for _, allowedPath := range allowedPaths {
+    if strings.HasPrefix(path, allowedPath) {
+      return true
+    }
+  }
+  return false
+}
+
+// Sets prospectors of filebeat configuration
+func setProspectors(config interface{}, newProspectors interface{}) {
+  filebeat := getElement(config, "filebeat")
+  filebeat.(map[string]interface{})["prospectors"] = newProspectors
+}
+
+// Gets prospectors from given filebeat configuration
+func getProspectors(config  interface{}) interface{} {
+  return getElement(config, "filebeat", "prospectors")
+}
+
+// Retrieves element from given path in map of maps structure (e.g. YAML model)
+func getElement(config interface{}, path ...string) interface{} {
+  var object interface{} = config
+  for target := 0; target < len(path); target++ {
+		if mmap, ok := object.(map[string]interface{}); ok {
+      object = mmap[path[target]]
+    }
+	}
+	return object
+}

--- a/backends/beats/filebeat/render.go
+++ b/backends/beats/filebeat/render.go
@@ -186,6 +186,10 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 
 	newConfig.Beats.Version = fbc.Beats.Version // inherit beats version number, it's null at request time and not comparable
 	newConfig.Beats.RunMigrations(newConfig.CachePath())
+
+  // Remove prospectors targeting non-allowed paths
+  newConfig.PruneDisallowedProspectors()
+
 	if !fbc.Beats.Equals(newConfig.Beats) {
 		log.Infof("[%s] Configuration change detected, rewriting configuration file.", fbc.Name())
 		fbc.Beats.Update(newConfig.Beats)
@@ -194,6 +198,11 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 	}
 
 	return false
+}
+
+func (fbc *FileBeatConfig) PruneDisallowedProspectors() {
+    allowedPaths := fbc.Beats.Context.UserConfig.AllowedPaths;
+    PruneDisallowedProspectors(fbc.Beats.Container.(map[string]interface{}), allowedPaths)
 }
 
 func (fbc *FileBeatConfig) ValidateConfigurationFile() bool {

--- a/backends/beats/filebeat/render.go
+++ b/backends/beats/filebeat/render.go
@@ -188,7 +188,10 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 	newConfig.Beats.RunMigrations(newConfig.CachePath())
 
   // Remove prospectors targeting non-allowed paths
-  newConfig.PruneDisallowedProspectors()
+  if !newConfig.PruneDisallowedProspectors() {
+		log.Info("Pruning disallowed prospector configurations failed, new configuration ignored.")
+		return false
+	}
 
 	if !fbc.Beats.Equals(newConfig.Beats) {
 		log.Infof("[%s] Configuration change detected, rewriting configuration file.", fbc.Name())
@@ -200,9 +203,9 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 	return false
 }
 
-func (fbc *FileBeatConfig) PruneDisallowedProspectors() {
+func (fbc *FileBeatConfig) PruneDisallowedProspectors() bool {
     allowedPaths := fbc.Beats.Context.UserConfig.AllowedPaths;
-    PruneDisallowedProspectors(fbc.Beats.Container.(map[string]interface{}), allowedPaths)
+    return PruneDisallowedProspectors(fbc.Beats.Container.(map[string]interface{}), allowedPaths)
 }
 
 func (fbc *FileBeatConfig) ValidateConfigurationFile() bool {

--- a/cfgfile/schema.go
+++ b/cfgfile/schema.go
@@ -32,6 +32,7 @@ type SidecarConfig struct {
 	UpdateInterval  int      `config:"update_interval"`
 	SendStatus      bool     `config:"send_status"`
 	ListLogFiles    []string `config:"list_log_files"`
+	AllowedPaths		[]string `config:"allowed_paths"`
 	Backends        []SidecarBackend
 }
 


### PR DESCRIPTION
Implements limiting on the collector-sidecar side what logs can be configured to be collected via new allowed_paths configuration option. The option is only applicable to filebeat collectors.

When log collection configuration is updated from server the log path glob expressions are matched against set of allowed paths regular expressions. All the paths for prospector must match at least one allowed path expression or prospector is discarded with logged warning message. For backwards compatibility, anything can be collected if no allowed_paths are configured.
