### PR TITLE
Added -NODEID switch to windows install and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,15 @@ _**The Windows installation path changed to `C:\Program Files` with version 0.0.
 It's also possible to run the installer in silent mode with
 
 ```
-  $ collector_sidecar_installer.exe /S -SERVERURL=http://10.0.2.2:9000/api -TAGS="windows,iis"
+  $ collector_sidecar_installer.exe /S -SERVERURL=http://10.0.2.2:9000/api -TAGS="windows,iis -NODEID=your_node_name"
+```
+
+Default values
+
+```
+  SERVERURL=http://127.0.0.1:9000/api
+  TAGS="windows,iis"
+  NODEID=<FULL COMPUTER NAME> (DNS name)
 ```
 
 Edit `C:\Program Files\graylog\collector-sidecar\collector_sidecar.yml`.
@@ -197,7 +205,9 @@ Each backend can be enabled/disabled and should point to a binary of the actual 
   * Install the [glide package manager](https://glide.sh)
   * run `glide install` in the collector-sidecar directory
   * (for Go <1.6 `export GO15VENDOREXPERIMENT=1`)
-  * run `make build`
+  * run `make build` for Unix builds
+  * run `make build-windows` for Windows builds
+  * check the Makefile for more build targets
 
 ## Development
 

--- a/collector_sidecar_windows.yml
+++ b/collector_sidecar_windows.yml
@@ -3,7 +3,7 @@ update_interval: 10
 tls_skip_verify: false
 send_status: true
 list_log_files:
-node_id: graylog-collector-sidecar
+node_id: <NODEID>
 collector_id: file:C:\Program Files\graylog\collector-sidecar\collector-id
 cache_path: C:\Program Files\graylog\collector-sidecar\cache
 log_path: C:\Program Files\graylog\collector-sidecar\logs

--- a/dist/GetFullComputerName.nsh
+++ b/dist/GetFullComputerName.nsh
@@ -1,19 +1,16 @@
 !macro _GetFullComputerName
-
-  Var /GLOBAL ComputerName
-  Var /GLOBAL PrimaryDomainName
-  Var /GLOBAL FullComputerName
+  Push $R0
+  Push $R1
 
   ReadRegStr $0 HKLM "System\CurrentControlSet\Control\ComputerName\ActiveComputerName" "ComputerName"
-  StrCpy $ComputerName $0
+  StrCpy $R0 $0
 
   StrCpy $0 0
   EnumRegKey $1 HKLM "System\CurrentControlSet\Services\Tcpip\Parameters\DNSRegisteredAdapters" $0
   ReadRegStr $0 HKLM "System\CurrentControlSet\Services\Tcpip\Parameters\DNSRegisteredAdapters\$1" "PrimaryDomainName"
 
-  StrCpy $PrimaryDomainName $0
-  StrCpy $FullComputerName "$ComputerName.$PrimaryDomainName"
+  StrCpy $R1 "$R0.$0"
 
-  Push $FullComputerName
+  Push "$R1"
 
 !macroend

--- a/dist/GetFullComputerName.nsh
+++ b/dist/GetFullComputerName.nsh
@@ -1,0 +1,19 @@
+!macro _GetFullComputerName
+
+  Var /GLOBAL ComputerName
+  Var /GLOBAL PrimaryDomainName
+  Var /GLOBAL FullComputerName
+
+  ReadRegStr $0 HKLM "System\CurrentControlSet\Control\ComputerName\ActiveComputerName" "ComputerName"
+  StrCpy $ComputerName $0
+
+  StrCpy $0 0
+  EnumRegKey $1 HKLM "System\CurrentControlSet\Services\Tcpip\Parameters\DNSRegisteredAdapters" $0
+  ReadRegStr $0 HKLM "System\CurrentControlSet\Services\Tcpip\Parameters\DNSRegisteredAdapters\$1" "PrimaryDomainName"
+
+  StrCpy $PrimaryDomainName $0
+  StrCpy $FullComputerName "$ComputerName.$PrimaryDomainName"
+
+  Push $FullComputerName
+
+!macroend

--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -17,6 +17,7 @@
   !include WordFunc.nsh
   !include x64.nsh
   !include IfKeyExists.nsh
+  !include GetFullComputerName.nsh
 
   VIProductVersion "0.${VERSION}${VERSION_SUFFIX}"
   VIAddVersionKey "FileVersion" "${VERSION}"
@@ -43,6 +44,8 @@
   Var Dialog
   Var Label
   Var GraylogDir
+  Var ParamNodeId
+  Var NodeId
 
 
 ;--------------------------------
@@ -167,6 +170,7 @@ Section "Post"
   ${GetParameters} $Params
   ${GetOptions} $Params "-SERVERURL=" $ParamServerUrl
   ${GetOptions} $Params "-TAGS=" $ParamTags
+  ${GetOptions} $Params "-NODEID=" $ParamNodeId
 
   ${If} $ParamServerUrl != ""
     StrCpy $ServerUrl $ParamServerUrl
@@ -186,6 +190,9 @@ Section "Post"
 
     Loop_End:
   ${EndIf}
+  ${If} $ParamNodeId != ""
+    StrCpy $NodeId $ParamNodeId
+  ${EndIf}
 
   ; default for silent install
   ${If} $ServerUrl == ""
@@ -194,9 +201,15 @@ Section "Post"
   ${If} $Tags == ""
     StrCpy $Tags "windows, iis"
   ${EndIf}
+  ${If} $NodeId == ""
+    !insertmacro _GetFullComputerName
+    Pop $FullComputerName
+    StrCpy $NodeId $FullComputerName
+  ${EndIf}
 
   !insertmacro _ReplaceInFile "$INSTDIR\collector_sidecar.yml" "<SERVERURL>" $ServerUrl
   !insertmacro _ReplaceInFile "$INSTDIR\collector_sidecar.yml" "<TAGS>" `[$Tags]`
+  !insertmacro _ReplaceInFile "$INSTDIR\collector_sidecar.yml" "<NODEID>" $NodeId
 
 SectionEnd
  

--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -46,7 +46,7 @@
   Var GraylogDir
   Var ParamNodeId
   Var NodeId
-
+  Var InputNodeId
 
 ;--------------------------------
 ;Modern UI Configuration  
@@ -203,8 +203,8 @@ Section "Post"
   ${EndIf}
   ${If} $NodeId == ""
     !insertmacro _GetFullComputerName
-    Pop $FullComputerName
-    StrCpy $NodeId $FullComputerName
+    Pop $R1
+    StrCpy $NodeId $R1
   ${EndIf}
 
   !insertmacro _ReplaceInFile "$INSTDIR\collector_sidecar.yml" "<SERVERURL>" $ServerUrl
@@ -283,6 +283,14 @@ Function nsDialogsPage
   ${NSD_CreateText} 50 70 75% 12u "windows, iis"
   Pop $InputTags
 
+  !insertmacro _GetFullComputerName
+  Pop $R1
+  StrCpy $NodeId $R1
+  ${NSD_CreateLabel} 0 100 100% 12u "Please enter the Node ID (optional):"
+  Pop $Label
+  ${NSD_CreateText} 50 120 75% 12u "$NodeId"
+  Pop $InputNodeId
+
   nsDialogs::Show
 FunctionEnd
 
@@ -296,6 +304,10 @@ Function nsDialogsPageLeave
   ${EndIf}
   ${If} $Tags == ""
       MessageBox MB_OK "Please enter one or more tags!"
+      Abort
+  ${EndIf}
+  ${If} $NodeId == ""
+      MessageBox MB_OK "Please enter the Node ID!"
       Abort
   ${EndIf}
 FunctionEnd


### PR DESCRIPTION
Added -NODEID Windows Installer silent switch for the NSIS package. The default value is the Full Computer Name (DNS name), extracted from the Windows Registry (implemented in GetFullComputerName.nsh).