### PR TITLE
Render prospector only if inputs are available

### DIFF
--- a/backends/beats/filebeat/render.go
+++ b/backends/beats/filebeat/render.go
@@ -176,7 +176,9 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 			}
 		}
 	}
-	newConfig.Beats.Set(prospector, "filebeat", "prospectors")
+	if len(response.Inputs) != 0 {
+		newConfig.Beats.Set(prospector, "filebeat", "prospectors")
+	}
 
 	for _, snippet := range response.Snippets {
 		if snippet.Backend == "filebeat" {

--- a/backends/beats/winlogbeat/render.go
+++ b/backends/beats/winlogbeat/render.go
@@ -126,7 +126,9 @@ func (wlbc *WinLogBeatConfig) RenderOnChange(response graylog.ResponseCollectorC
 			}
 		}
 	}
-	newConfig.Beats.Set(eventlogs, "winlogbeat", "event_logs")
+	if len(response.Inputs) != 0 {
+		newConfig.Beats.Set(eventlogs, "winlogbeat", "event_logs")
+	}
 
 	for _, snippet := range response.Snippets {
 		if snippet.Backend == "winlogbeat" {


### PR DESCRIPTION
In order to use snippets as main configuration container the Sidecar should not render an empty prospector. This prevents user defined inputs in snippets.

Fixes #208