### PR TITLE
Add more installer switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ them as a valid configuration file for various log collectors. You can think of 
 ## Documentation
 
 Please check our official [documentation](http://docs.graylog.org/en/latest/pages/collector_sidecar.html) for more information.
-Especially the [Step-by-Step](http://docs.graylog.org/en/2.1/pages/collector_sidecar.html#step-by-step-guide) guide to get the first setup running.
+Especially the [Step-by-Step](http://docs.graylog.org/en/2.4/pages/collector_sidecar.html#step-by-step-guide) guide to get the first setup running.
 
 ## Installation
 
 | Sidecar version  | Graylog server version |
 | ---------------- | ---------------------- |
 | 0.0.9            | 2.1.x                  |
-| 0.1.x            | 2.2.x, 2.3.x           |
+| 0.1.x            | 2.2.x, 2.3.x, 2.4.x    |
 
 [Download a package](https://github.com/Graylog2/collector-sidecar/releases) and install it on the target system.
 
@@ -28,7 +28,7 @@ Especially the [Step-by-Step](http://docs.graylog.org/en/2.1/pages/collector_sid
 The Beats binaries (Filebeat and Winlogeventbeat) are included in the Sidecar package. So installation is just one command.
 
 ```
-  $ sudo dpkg -i collector-sidecar_0.1.4-1_amd64.deb
+  $ sudo dpkg -i collector-sidecar_0.1.5-1_amd64.deb
 ```
 
 Edit `/etc/graylog/collector-sidecar/collector_sidecar.yml`, you should set at least the correct URL to your Graylog server and proper tags.
@@ -49,7 +49,7 @@ Create a system service and start it
 **CentOS**
 
 ```
-  $ sudo rpm -i collector-sidecar-0.1.4-1.x86_64.rpm
+  $ sudo rpm -i collector-sidecar-0.1.5-1.x86_64.rpm
 ```
 
 Activate the Sidecar as a system service
@@ -80,6 +80,20 @@ Edit `C:\Program Files\graylog\collector-sidecar\collector_sidecar.yml`.
   $ C:\Program Files\graylog\collector-sidecar\graylog-collector-sidecar.exe -service start
 ```
 
+All installer options:
+
+| Parameter             | Description                           | Default                   |
+|-----------------------|-------------------------------------------------------------------|
+| `-SERVERURL`          | URL to the Graylog API                | http://127.0.0.1:9000/api |
+| `-TAGS`               | List of tags                          | "windows, iis"            |
+| `-NODEID`             | Name of the instance                  | graylog-collector-sidecar |
+| `-UPDATE_INTERVAL`    | seconds between configuration updates | 10                        |
+| `-TLS_SKIP_VERIFY`    | ignore self-signed API certificates   | false                     |
+| `-SEND_STATUS`        | send host metrics back to Graylog     | true                      |
+| `-NXLOG_ENABLED`      | enable NXLog backend                  | false                     |
+| `-FILEBEAT_ENABLED`   | enable Filebeat                       | true                      |
+| `-WINLOGBEAT_ENABLED` | enable Winlogbeat                     | true                      |
+
 ### NXLog backend
 
 **Ubuntu**
@@ -91,7 +105,7 @@ Install the NXLog package from the offical download [page](https://nxlog.org/pro
   $ sudo update-rc.d -f nxlog remove
   $ sudo gpasswd -a nxlog adm
  
-  $ sudo dpkg -i collector-sidecar_0.1.4-1_amd64.deb
+  $ sudo dpkg -i collector-sidecar_0.1.5-1_amd64.deb
   $ sudo chown -R nxlog.nxlog /var/spool/collector-sidecar/nxlog
 ```
 
@@ -115,7 +129,7 @@ Edit `/etc/graylog/collector-sidecar/collector_sidecar.yml`accordingly.
   $ sudo gpasswd -a nxlog root
   $ sudo chown -R nxlog.nxlog /var/spool/collector-sidecar/nxlog
 
-  $ sudo rpm -i collector-sidecar-0.1.4-1.x86_64.rpm
+  $ sudo rpm -i collector-sidecar-0.1.5-1.x86_64.rpm
 ```
 
 Activate the Sidecar as a system service

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Especially the [Step-by-Step](http://docs.graylog.org/en/2.4/pages/collector_sid
 The Beats binaries (Filebeat and Winlogeventbeat) are included in the Sidecar package. So installation is just one command.
 
 ```
-  $ sudo dpkg -i collector-sidecar_0.1.5-1_amd64.deb
+  $ sudo dpkg -i collector-sidecar_0.1.4-1_amd64.deb
 ```
 
 Edit `/etc/graylog/collector-sidecar/collector_sidecar.yml`, you should set at least the correct URL to your Graylog server and proper tags.
@@ -49,7 +49,7 @@ Create a system service and start it
 **CentOS**
 
 ```
-  $ sudo rpm -i collector-sidecar-0.1.5-1.x86_64.rpm
+  $ sudo rpm -i collector-sidecar-0.1.4-1.x86_64.rpm
 ```
 
 Activate the Sidecar as a system service
@@ -105,7 +105,7 @@ Install the NXLog package from the offical download [page](https://nxlog.org/pro
   $ sudo update-rc.d -f nxlog remove
   $ sudo gpasswd -a nxlog adm
  
-  $ sudo dpkg -i collector-sidecar_0.1.5-1_amd64.deb
+  $ sudo dpkg -i collector-sidecar_0.1.4-1_amd64.deb
   $ sudo chown -R nxlog.nxlog /var/spool/collector-sidecar/nxlog
 ```
 
@@ -129,7 +129,7 @@ Edit `/etc/graylog/collector-sidecar/collector_sidecar.yml`accordingly.
   $ sudo gpasswd -a nxlog root
   $ sudo chown -R nxlog.nxlog /var/spool/collector-sidecar/nxlog
 
-  $ sudo rpm -i collector-sidecar-0.1.5-1.x86_64.rpm
+  $ sudo rpm -i collector-sidecar-0.1.4-1.x86_64.rpm
 ```
 
 Activate the Sidecar as a system service

--- a/collector_sidecar_windows.yml
+++ b/collector_sidecar_windows.yml
@@ -1,9 +1,9 @@
 server_url: <SERVERURL> 
-update_interval: 10
-tls_skip_verify: false
-send_status: true
+update_interval: <UPDATEINTERVAL>
+tls_skip_verify: <TLSSKIPVERIFY>
+send_status: <SENDSTATUS>
 list_log_files:
-node_id: graylog-collector-sidecar
+node_id: <NODEID>
 collector_id: file:C:\Program Files\graylog\collector-sidecar\collector-id
 cache_path: C:\Program Files\graylog\collector-sidecar\cache
 log_path: C:\Program Files\graylog\collector-sidecar\logs
@@ -12,14 +12,14 @@ log_max_age: 604800
 tags: <TAGS>
 backends:
     - name: nxlog
-      enabled: false
+      enabled: <NXLOGENABLED>
       binary_path: C:\Program Files (x86)\nxlog\nxlog.exe
       configuration_path: C:\Program Files\graylog\collector-sidecar\generated\nxlog.conf
     - name: winlogbeat
-      enabled: true
+      enabled: <WINLOGBEATENABLED>
       binary_path: C:\Program Files\graylog\collector-sidecar\winlogbeat.exe
       configuration_path: C:\Program Files\graylog\collector-sidecar\generated\winlogbeat.yml
     - name: filebeat
-      enabled: true
+      enabled: <FILEBEATENABLED>
       binary_path: C:\Program Files\graylog\collector-sidecar\filebeat.exe
       configuration_path: C:\Program Files\graylog\collector-sidecar\generated\filebeat.yml


### PR DESCRIPTION
Like requested from a couple of users this PR adds more switches to the Windows installer.
In silent mode it's now possible to set these:

```
  -SERVERURL
  -TAGS
  -NODEID
  -UPDATE_INTERVAL
  -TLS_SKIP_VERIFY
  -SEND_STATUS
  -NXLOG_ENABLED
  -FILEBEAT_ENABLED
  -WINLOGBEAT_ENABLED
```

The interactive installer can set the following options:

```
  -SERVERURL
  -TAGS
  -NODEID
```

Closes #176 
Replaces #198 