### PR TITLE
Upgrade to Glide 0.13.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ endif
 
 GIT_REV=$(shell git rev-parse --short HEAD)
 BUILD_OPTS = -ldflags "-s -X github.com/Graylog2/collector-sidecar/common.GitRevision=$(GIT_REV) -X github.com/Graylog2/collector-sidecar/common.CollectorVersion=$(COLLECTOR_VERSION) -X github.com/Graylog2/collector-sidecar/common.CollectorVersionSuffix=$(COLLECTOR_VERSION_SUFFIX)"
+GLIDE_VERSION = v0.13.1
 
 TEST_SUITE = \
 	github.com/Graylog2/collector-sidecar/backends/nxlog \
@@ -38,17 +39,17 @@ deps: glide
 
 glide:
 ifeq ($(shell uname),Darwin)
-	curl -L https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-darwin-amd64.zip -o glide.zip
+	curl -s -L https://github.com/Masterminds/glide/releases/download/$(GLIDE_VERSION)/glide-$(GLIDE_VERSION)-darwin-amd64.zip -o glide.zip
 	unzip glide.zip
 	mv ./darwin-amd64/glide ./glide
 	rm -fr ./darwin-amd64
-	rm ./glide.zip
+	rm -f ./glide.zip
 else
-	curl -L https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-linux-amd64.zip -o glide.zip
+	curl -s -L https://github.com/Masterminds/glide/releases/download/$(GLIDE_VERSION)/glide-$(GLIDE_VERSION)-linux-amd64.zip -o glide.zip
 	unzip glide.zip
 	mv ./linux-amd64/glide ./glide
 	rm -fr ./linux-amd64
-	rm ./glide.zip
+	rm -f ./glide.zip
 endif
 
 test: ## Run tests


### PR DESCRIPTION
Glide 0.10.2 (compiled with Go 1.6) fails on macOS High Sierra 10.13.2 (17C205).
Seems to be related to golang/go#17182.

Kernel version:

```
$ uname -v
Darwin Kernel Version 17.3.0: Thu Nov  9 18:09:22 PST 2017; root:xnu-4570.31.3~1/RELEASE_X86_64
```

Error with Glide 0.10.2:

```
$ ./glide install
failed MSpanList_Insert 0x9b8000 0x2ee76050da1e0 0x0 0x0
fatal error: MSpanList_Insert

runtime stack:
runtime.throw(0x640ae0, 0x10)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/panic.go:530 +0x90 fp=0x7ffeefbfeb60 sp=0x7ffeefbfeb48
runtime.(*mSpanList).insert(0x89b588, 0x9b8000)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mheap.go:933 +0x293 fp=0x7ffeefbfeb90 sp=0x7ffeefbfeb60
runtime.(*mheap).freeSpanLocked(0x89ad80, 0x9b8000, 0x100, 0x0)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mheap.go:809 +0x4be fp=0x7ffeefbfebf8 sp=0x7ffeefbfeb90
runtime.(*mheap).grow(0x89ad80, 0x8, 0x0)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mheap.go:675 +0x2a0 fp=0x7ffeefbfec50 sp=0x7ffeefbfebf8
runtime.(*mheap).allocSpanLocked(0x89ad80, 0x1, 0x0)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mheap.go:553 +0x4e3 fp=0x7ffeefbfeca8 sp=0x7ffeefbfec50
runtime.(*mheap).alloc_m(0x89ad80, 0x1, 0x15, 0x0)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mheap.go:437 +0x119 fp=0x7ffeefbfecd8 sp=0x7ffeefbfeca8
runtime.(*mheap).alloc.func1()
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mheap.go:502 +0x41 fp=0x7ffeefbfed08 sp=0x7ffeefbfecd8
runtime.systemstack(0x7ffeefbfed28)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/asm_amd64.s:307 +0xab fp=0x7ffeefbfed10 sp=0x7ffeefbfed08
runtime.(*mheap).alloc(0x89ad80, 0x1, 0x10000000015, 0x1686f)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mheap.go:503 +0x63 fp=0x7ffeefbfed58 sp=0x7ffeefbfed10
runtime.(*mcentral).grow(0x89c980, 0x0)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mcentral.go:209 +0x93 fp=0x7ffeefbfedc0 sp=0x7ffeefbfed58
runtime.(*mcentral).cacheSpan(0x89c980, 0x8956b8)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mcentral.go:89 +0x47d fp=0x7ffeefbfee00 sp=0x7ffeefbfedc0
runtime.(*mcache).refill(0x9b4000, 0x15, 0x7ffeefbfee68)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/mcache.go:119 +0xcc fp=0x7ffeefbfee38 sp=0x7ffeefbfee00
runtime.mallocgc.func2()
    /usr/local/Cellar/go/1.6/libexec/src/runtime/malloc.go:642 +0x2b fp=0x7ffeefbfee58 sp=0x7ffeefbfee38
runtime.systemstack(0x7ffeefbfeef8)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/asm_amd64.s:307 +0xab fp=0x7ffeefbfee60 sp=0x7ffeefbfee58
runtime.mallocgc(0x180, 0x5dcd80, 0x0, 0x800000000)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/malloc.go:643 +0x869 fp=0x7ffeefbfef38 sp=0x7ffeefbfee60
runtime.newobject(0x5dcd80, 0x895cb0)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/malloc.go:781 +0x42 fp=0x7ffeefbfef60 sp=0x7ffeefbfef38
runtime.malg(0x8000, 0x896060)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/proc.go:2634 +0x27 fp=0x7ffeefbfef98 sp=0x7ffeefbfef60
runtime.mpreinit(0x896600)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/os1_darwin.go:140 +0x1f fp=0x7ffeefbfefb0 sp=0x7ffeefbfef98
runtime.mcommoninit(0x896600)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/proc.go:494 +0x105 fp=0x7ffeefbfeff8 sp=0x7ffeefbfefb0
runtime.schedinit()
    /usr/local/Cellar/go/1.6/libexec/src/runtime/proc.go:434 +0x79 fp=0x7ffeefbff040 sp=0x7ffeefbfeff8
runtime.rt0_go(0x7ffeefbff078, 0x2, 0x7ffeefbff078, 0x0, 0x0, 0x2, 0x7ffeefbff260, 0x7ffeefbff268, 0x0, 0x7ffeefbff270, ...)
    /usr/local/Cellar/go/1.6/libexec/src/runtime/asm_amd64.s:138 +0x132 fp=0x7ffeefbff048 sp=0x7ffeefbff040
make: *** [deps] Error 2
```