### PR TITLE
Cleanup backend access

### DIFF
--- a/api/graylog.go
+++ b/api/graylog.go
@@ -232,8 +232,8 @@ func GetTlsConfig(ctx *context.Ctx) *tls.Config {
 func NewStatusRequest() graylog.StatusRequest {
 	statusRequest := graylog.StatusRequest{Backends: make(map[string]system.Status)}
 	combined, count := system.GlobalStatus.Status, 0
-	for name := range daemon.Daemon.Runner {
-		backend := backends.Store.GetBackend(name)
+	for name, runner := range daemon.Daemon.Runner {
+		backend := runner.GetBackend()
 		statusRequest.Backends[name] = backend.Status()
 		if backend.Status().Status > combined {
 			combined = backend.Status().Status

--- a/backends/status.go
+++ b/backends/status.go
@@ -30,12 +30,13 @@ func (b *Backend) SetStatus(state int, message string) {
 	b.backendStatus.Set(state, message)
 }
 
+func (b *Backend)SetStatusLogErrorf(format string, args ...interface{}) error {
+	b.SetStatus(StatusError, fmt.Sprintf(format, args...))
+	log.Errorf(fmt.Sprintf("[%s] ", b.Name)+format, args...)
+	return fmt.Errorf(format, args)
+}
+
 func (b *Backend) Status() system.Status {
 	return b.backendStatus
 }
 
-func SetStatusLogErrorf(name string, format string, args ...interface{}) error {
-	Store.backends[name].SetStatus(StatusError, fmt.Sprintf(format, args...))
-	log.Errorf(fmt.Sprintf("[%s] ", name)+format, args...)
-	return fmt.Errorf(format, args)
-}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -98,6 +98,15 @@ func (dc *DaemonConfig) DeleteRunner(backendName string) {
 	delete(dc.Runner, backendName)
 }
 
+func (dc *DaemonConfig) GetRunnerByBackendId(id string) Runner {
+	for _, runner := range dc.Runner {
+		if runner.GetBackend().Id == id {
+			return runner
+		}
+	}
+	return nil
+}
+
 func (dc *DaemonConfig) SyncWithAssignments(context *context.Ctx) {
 	if dc.Runner == nil {
 		return
@@ -109,7 +118,7 @@ func (dc *DaemonConfig) SyncWithAssignments(context *context.Ctx) {
 		// update outdated runner backend
 		runnerBackend := runner.GetBackend()
 		if backend != nil && !runnerBackend.EqualSettings(backend) {
-			log.Info("Updating process configuration for: " + runner.Name())
+			log.Infof("[%s] Updating process configuration", runner.Name())
 			runner.SetBackend(*backend)
 		}
 

--- a/daemon/runner.go
+++ b/daemon/runner.go
@@ -27,7 +27,7 @@ type Runner interface {
 	Restart() error
 	Shutdown() error
 	SetDaemon(*DaemonConfig)
-	GetBackend() backends.Backend
+	GetBackend() *backends.Backend
 	SetBackend(backends.Backend)
 }
 


### PR DESCRIPTION
Fixes #238 

##Explanation
We store a 1:1 copy of the available collectors of the Graylog server in the structure called `backends.Store`. When a configuration is assigned to a Sidecar a new `Runner` instance is created with a _copy_ of the responding `Backend`. Now we have to make sure that status changes (as well as configuration changes/compares) are made to that copied `Backend` and not to the original list of backends. We need that copy to allow multiple instances of the same collector type.