### PR TITLE
Adjust status request to changes in the server

### DIFF
--- a/api/graylog.go
+++ b/api/graylog.go
@@ -230,13 +230,18 @@ func GetTlsConfig(ctx *context.Ctx) *tls.Config {
 }
 
 func NewStatusRequest() graylog.StatusRequest {
-	statusRequest := graylog.StatusRequest{Backends: make(map[string]system.Status)}
+	statusRequest := graylog.StatusRequest{Backends: make([]graylog.StatusRequestBackend, 0)}
 	combined, count := system.GlobalStatus.Status, 0
+
 	for name, runner := range daemon.Daemon.Runner {
-		backend := runner.GetBackend()
-		statusRequest.Backends[name] = backend.Status()
-		if backend.Status().Status > combined {
-			combined = backend.Status().Status
+		backendStatus := runner.GetBackend().Status()
+		statusRequest.Backends = append(statusRequest.Backends, graylog.StatusRequestBackend{
+			Name:    name,
+			Status:  backendStatus.Status,
+			Message: backendStatus.Message,
+		})
+		if backendStatus.Status > combined {
+			combined = backendStatus.Status
 		}
 		count++
 	}

--- a/api/graylog/requests.go
+++ b/api/graylog/requests.go
@@ -17,7 +17,6 @@ package graylog
 
 import (
 	"github.com/Graylog2/collector-sidecar/common"
-	"github.com/Graylog2/collector-sidecar/system"
 )
 
 type RegistrationRequest struct {
@@ -33,10 +32,16 @@ type NodeDetailsRequest struct {
 	Status          *StatusRequest  `json:"status,omitempty"`
 }
 
+type StatusRequestBackend struct {
+	Name    string `json:"name"`
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+}
+
 type StatusRequest struct {
-	Backends map[string]system.Status `json:"collectors"`
-	Status   int                      `json:"status"`
-	Message  string                   `json:"message"`
+	Backends []StatusRequestBackend `json:"collectors"`
+	Status   int                    `json:"status"`
+	Message  string                 `json:"message"`
 }
 
 type MetricsRequest struct {


### PR DESCRIPTION
The collector backend status data structure changed from a map to a set
of objects.

Refs Graylog2/graylog2-server#4885
Refs Graylog2/graylog2-server#4886