### PR TITLE
Change default paths to avoid another subdirectory

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -86,7 +86,7 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 		if runtime.GOOS == "windows" {
 			cachePath = filepath.Join(os.Getenv("SystemDrive")+"\\", "Program Files", "graylog", "sidecar", "cache")
 		} else {
-			cachePath = filepath.Join("/var", "cache", "graylog", "sidecar")
+			cachePath = filepath.Join("/var", "cache", "graylog-sidecar")
 		}
 		ctx.UserConfig.CachePath = cachePath
 		log.Errorf("No cache directory was configured. Using default: %s", cachePath)

--- a/dist/recipe.rb
+++ b/dist/recipe.rb
@@ -27,8 +27,8 @@ class GraylogSidecar < FPM::Cookery::Recipe
     bin.install '../../collectors/filebeat/linux/x86_64/filebeat'
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     etc('graylog/sidecar/generated').mkdir
-    var('log/graylog/sidecar').mkdir
-    var('run/graylog/sidecar').mkdir
+    var('log/graylog-sidecar').mkdir
+    var('run/graylog-sidecar').mkdir
     var('spool/graylog-sidecar/nxlog').mkdir
   end
 end

--- a/dist/recipe32.rb
+++ b/dist/recipe32.rb
@@ -27,8 +27,8 @@ class GraylogSidecar < FPM::Cookery::Recipe
     bin.install '../../collectors/filebeat/linux/x86/filebeat'
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     etc('graylog/sidecar/generated').mkdir
-    var('log/graylog/sidecar').mkdir
-    var('run/graylog/sidecar').mkdir
+    var('log/graylog-sidecar').mkdir
+    var('run/graylog-sidecar').mkdir
     var('spool/graylog-sidecar/nxlog').mkdir
   end
 end

--- a/sidecar-example.yml
+++ b/sidecar-example.yml
@@ -50,12 +50,12 @@ send_status: true
 list_log_files:
 
 # Directory where the sidecar stores internal data.
-# Default: "/var/cache/graylog/sidecar"
-cache_path: "/var/cache/graylog/sidecar"
+# Default: "/var/cache/graylog-sidecar"
+cache_path: "/var/cache/graylog-sidecar"
 
 # Directory where the sidecar stores logs for collectors and the sidecar itself.
-# Default: "/var/log/graylog/sidecar"
-log_path: "/var/log/graylog/sidecar"
+# Default: "/var/log/graylog-sidecar"
+log_path: "/var/log/graylog-sidecar"
 
 # TODO: Document or remove depending on the outcome of https://github.com/Graylog2/collector-sidecar/issues/251
 log_rotation_time: 86400


### PR DESCRIPTION
This brings the sidecar in line with the graylog-server package which
stores data in "/var/{log,lib}/graylog-server".