### PR TITLE
Install filebeat into /usr/lib/graylog-sidecar/filebeat

### DIFF
--- a/dist/recipe.rb
+++ b/dist/recipe.rb
@@ -24,7 +24,7 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   def install
     bin.install 'graylog-sidecar'
-    usr('lib/graylog-sidecar').install '../../collectors/filebeat/linux/x86_64/filebeat'
+    lib('graylog-sidecar').install '../../collectors/filebeat/linux/x86_64/filebeat'
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     etc('graylog/sidecar/generated').mkdir
     var('log/graylog/sidecar').mkdir

--- a/dist/recipe.rb
+++ b/dist/recipe.rb
@@ -24,7 +24,7 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   def install
     bin.install 'graylog-sidecar'
-    bin.install '../../collectors/filebeat/linux/x86_64/filebeat'
+    usr('lib/graylog-sidecar').install '../../collectors/filebeat/linux/x86_64/filebeat'
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     etc('graylog/sidecar/generated').mkdir
     var('log/graylog/sidecar').mkdir

--- a/dist/recipe32.rb
+++ b/dist/recipe32.rb
@@ -24,7 +24,7 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   def install
     bin.install 'graylog-sidecar'
-    bin.install '../../collectors/filebeat/linux/x86/filebeat'
+    usr('lib/graylog-sidecar').install '../../collectors/filebeat/linux/x86/filebeat'
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     etc('graylog/sidecar/generated').mkdir
     var('log/graylog/sidecar').mkdir

--- a/dist/recipe32.rb
+++ b/dist/recipe32.rb
@@ -24,7 +24,7 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   def install
     bin.install 'graylog-sidecar'
-    usr('lib/graylog-sidecar').install '../../collectors/filebeat/linux/x86/filebeat'
+    lib('graylog-sidecar').install '../../collectors/filebeat/linux/x86/filebeat'
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     etc('graylog/sidecar/generated').mkdir
     var('log/graylog/sidecar').mkdir


### PR DESCRIPTION
This avoids conflicts with the official filebeat DEB/RPM packages which also install into `/usr/bin`.

Fixes #211