### PR TITLE
Use shlex to split command argument list

### DIFF
--- a/api/graylog/responses.go
+++ b/api/graylog/responses.go
@@ -53,8 +53,8 @@ type ResponseCollectorBackend struct {
 	OperatingSystem      string   `json:"node_operating_system"`
 	ExecutablePath       string   `json:"executable_path"`
 	ConfigurationPath    string   `json:"configuration_path"`
-	ExecuteParameters    []string `json:"execute_parameters"`
-	ValidationParameters []string `json:"validation_parameters"`
+	ExecuteParameters    string `json:"execute_parameters"`
+	ValidationParameters string `json:"validation_parameters"`
 }
 
 type ResponseCollectorConfiguration struct {

--- a/backends/registry.go
+++ b/backends/registry.go
@@ -32,13 +32,13 @@ type backendStore struct {
 
 func (bs *backendStore) SetBackend(backend Backend) {
 	bs.backends[backend.Id] = &backend
-	executeParameters, err := common.SprintfList(backend.ExecuteParameters, backend.ConfigurationPath)
+	executeParameters, err := common.Sprintf(backend.ExecuteParameters, backend.ConfigurationPath)
 	if err != nil {
 		log.Errorf("Invalid execute parameters, skip adding backend: %s", backend.Name)
 		return
 	}
 	bs.backends[backend.Id].ExecuteParameters = executeParameters
-	validationParameters, err := common.SprintfList(backend.ValidationParameters, backend.ConfigurationPath)
+	validationParameters, err := common.Sprintf(backend.ValidationParameters, backend.ConfigurationPath)
 	if err != nil {
 		log.Errorf("Invalid validation parameters, skip adding backend: %s", backend.Name)
 		return

--- a/common/helper.go
+++ b/common/helper.go
@@ -157,19 +157,16 @@ func IsInList(id string, list []string) bool {
 	return false
 }
 
-func SprintfList(list []string, values ...interface{}) (result []string, err error) {
-	for _, entry := range list {
-		matched, err := regexp.MatchString("%[vTsqxX]", entry)
-		if err != nil {
-			return nil, err
-		}
-		if matched {
-			result = append(result, fmt.Sprintf(entry, values...))
-		} else {
-			result = append(result, entry)
-		}
+func Sprintf(format string, values ...interface{}) (string, error) {
+	matched, err := regexp.MatchString("%[vTsqxX]", format)
+	if err != nil {
+		return "", err
 	}
-	return
+	if matched {
+		return fmt.Sprintf(format, values...), nil
+	} else {
+		return format, nil
+	}
 }
 
 type PathMatchResult struct {

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -25,6 +25,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/flynn-archive/go-shlex"
+
 	"github.com/Graylog2/collector-sidecar/backends"
 	"github.com/Graylog2/collector-sidecar/common"
 	"github.com/Graylog2/collector-sidecar/context"
@@ -34,7 +36,7 @@ import (
 type ExecRunner struct {
 	RunnerCommon
 	exec           string
-	args           []string
+	args           string
 	stderr, stdout string
 	output         []byte
 	isRunning      atomic.Value
@@ -183,7 +185,11 @@ func (r *ExecRunner) start() error {
 	}
 
 	// setup process environment
-	r.cmd = exec.Command(r.exec, r.args...)
+	quotedArgs, err := shlex.Split(r.args)
+	if err != nil {
+		return err
+	}
+	r.cmd = exec.Command(r.exec, quotedArgs...)
 	r.cmd.Dir = r.daemon.Dir
 	r.cmd.Env = append(os.Environ(), r.daemon.Env...)
 

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -18,7 +18,6 @@ package daemon
 import (
 	"errors"
 	"os/exec"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -34,7 +33,7 @@ import (
 type SvcRunner struct {
 	RunnerCommon
 	exec         string
-	args         []string
+	args         string
 	startTime    time.Time
 	serviceName  string
 	isSupervised atomic.Value
@@ -143,7 +142,7 @@ func (r *SvcRunner) ValidateBeforeStart() error {
 	serviceConfig := mgr.Config{
 		DisplayName:    "Graylog collector sidecar - " + r.name + " backend",
 		Description:    "Wrapper service for the NXLog backend",
-		BinaryPathName: "\"" + r.exec + "\" " + strings.Join(r.args, " ")}
+		BinaryPathName: "\"" + r.exec + "\" " + r.args}
 
 	s, err := m.OpenService(r.serviceName)
 	// service exist so we only update the properties

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
-hash: 8c3fa547f85bc8d3445aa71b93fac56bf51d503486867b79beadb97303d1c38d
-updated: 2017-06-19T12:35:05.244834712+02:00
+hash: bc35d7d5b047ba6e288278d289184b6fea6e4f9c4f878fd7c3e06c210fde0d8a
+updated: 2018-08-15T16:57:35.735955193+02:00
 imports:
 - name: bitbucket.org/tebeka/strftime
   version: 2194253a23c090a4d5953b152a3c63fb5da4f5a4
 - name: github.com/elastic/gosigar
   version: 2716c1fe855ee5c88eae707195e0688374458c92
+- name: github.com/flynn-archive/go-shlex
+  version: 3f9db97f856818214da2e1057f8ad84803971cff
 - name: github.com/go-ole/go-ole
   version: 5e9c030faf78847db7aa77e3661b9cc449de29b7
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,3 +18,4 @@ import:
 - package: bitbucket.org/tebeka/strftime
 - package: github.com/elastic/gosigar
 - package: github.com/rifflock/lfshook
+- package: github.com/flynn-archive/go-shlex


### PR DESCRIPTION
After https://github.com/Graylog2/graylog2-server/issues/4889 is fixed the arguments list is stored as single string so we need to split it up.