### PR TITLE
Add X-Requested-By header

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Especially the [Step-by-Step](http://docs.graylog.org/en/2.4/pages/collector_sid
 | ---------------- | ---------------------- |
 | 0.0.9            | 2.1.x                  |
 | 0.1.x            | 2.2.x, 2.3.x, 2.4.x    |
+| 0.2.x            | 2.5.x                  |
 
 [Download a package](https://github.com/Graylog2/collector-sidecar/releases) and install it on the target system.
 

--- a/api/rest/rest.go
+++ b/api/rest/rest.go
@@ -35,6 +35,7 @@ import (
 var (
 	log = logger.Log()
 	userAgent = "Graylog Collector v" + common.CollectorVersion
+	customRequestHeader = "sidecar"
 )
 
 const (
@@ -130,6 +131,7 @@ func (c *Client) NewRequest(method, urlStr string, params map[string]string, bod
 	req.Header.Add("Accept", mediaType)
 	req.Header.Add("User-Agent", userAgent)
 	req.Header.Add("X-Graylog-Collector-Version", common.CollectorVersion)
+	req.Header.Add("X-Requested-By", customRequestHeader)
 	return req, nil
 }
 


### PR DESCRIPTION
In order to make the Sidecar work with Graylog after merging https://github.com/Graylog2/graylog2-server/pull/4998 we need to set the X-Requested-by header in all api requests.