### PR TITLE
Cleanup action handling

### DIFF
--- a/daemon/action_handler.go
+++ b/daemon/action_handler.go
@@ -46,7 +46,7 @@ func startAction(backend *backends.Backend) {
 	for id, runner := range Daemon.Runner {
 		if id == backend.Id {
 			if !runner.Running() {
-				log.Infof("[%s] Staring collector", backend.Name)
+				log.Infof("[%s] Got remote start command", backend.Name)
 				runner.Restart()
 			} else {
 				log.Infof("Collector [%s] is already running, skipping start action.", backend.Name)
@@ -58,7 +58,7 @@ func startAction(backend *backends.Backend) {
 func restartAction(backend *backends.Backend) {
 	for id, runner := range Daemon.Runner {
 		if id == backend.Id {
-			log.Infof("[%s] Restarting collector", backend.Name)
+			log.Infof("[%s] Got remote restarting command", backend.Name)
 			runner.Restart()
 		}
 	}
@@ -67,7 +67,7 @@ func restartAction(backend *backends.Backend) {
 func stopAction(backend *backends.Backend) {
 	for id, runner := range Daemon.Runner {
 		if id == backend.Id {
-			log.Infof("[%s] Stopping collector", backend.Name)
+			log.Infof("[%s] Got remote stop command", backend.Name)
 			runner.Shutdown()
 		}
 	}

--- a/daemon/action_handler.go
+++ b/daemon/action_handler.go
@@ -58,7 +58,7 @@ func startAction(backend *backends.Backend) {
 func restartAction(backend *backends.Backend) {
 	for id, runner := range Daemon.Runner {
 		if id == backend.Id {
-			log.Infof("[%s] Got remote restarting command", backend.Name)
+			log.Infof("[%s] Got remote restart command", backend.Name)
 			runner.Restart()
 		}
 	}

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -243,10 +243,12 @@ func (r *ExecRunner) Restart() error {
 }
 
 func (r *ExecRunner) restart() error {
-	r.stop()
-	for timeout := 0; r.Running() || timeout >= 5; timeout++ {
-		log.Debugf("[%s] waiting for process to finish...", r.Name())
-		time.Sleep(1 * time.Second)
+	if r.Running() {
+		r.stop()
+		for timeout := 0; r.Running() || timeout >= 5; timeout++ {
+			log.Debugf("[%s] waiting for process to finish...", r.Name())
+			time.Sleep(1 * time.Second)
+		}
 	}
 	r.start()
 

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -281,10 +281,12 @@ func (r *SvcRunner) Restart() error {
 }
 
 func (r *SvcRunner) restart() error {
-	r.stop()
-	for timeout := 0; r.Running() || timeout >= 5; timeout++ {
-		log.Debugf("[%s] waiting for process to finish...", r.Name())
-		time.Sleep(1 * time.Second)
+	if r.Running() {
+		r.stop()
+		for timeout := 0; r.Running() || timeout >= 5; timeout++ {
+			log.Debugf("[%s] waiting for process to finish...", r.Name())
+			time.Sleep(1 * time.Second)
+		}
 	}
 	r.start()
 


### PR DESCRIPTION
Removes duplicate log lines and prevent unnecessary stop action if the collector is not running.