### PR TITLE
Fix symlink detection in PathMatch on non-existing files

### DIFF
--- a/common/helper.go
+++ b/common/helper.go
@@ -177,11 +177,13 @@ type PathMatchResult struct {
 
 func PathMatch(path string, patternList []string) (PathMatchResult, error) {
 	result := PathMatchResult{}
-	resolvedPath, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return result, err
-	} else {
-		result.Path = resolvedPath
+	if _, err := os.Stat(path); os.IsExist(err) {
+		resolvedPath, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return result, err
+		} else {
+			result.Path = resolvedPath
+		}
 	}
 
 	if result.Path != path {


### PR DESCRIPTION
EvalSymlinks will fail if the path does not exist.
Check beforehand.
Fixes #279