### PR TITLE
Fix collector_whitelist feature

### DIFF
--- a/common/helper.go
+++ b/common/helper.go
@@ -177,13 +177,15 @@ type PathMatchResult struct {
 
 func PathMatch(path string, patternList []string) (PathMatchResult, error) {
 	result := PathMatchResult{}
-	if _, err := os.Stat(path); os.IsExist(err) {
+	if _, err := os.Stat(path); err == nil {
 		resolvedPath, err := filepath.EvalSymlinks(path)
 		if err != nil {
 			return result, err
 		} else {
 			result.Path = resolvedPath
 		}
+	} else {
+		return result, err
 	}
 
 	if result.Path != path {


### PR DESCRIPTION
Fix file existing check. Inverse `if` logic and return in case the file doesn't exist.

See https://github.com/Graylog2/collector-sidecar/issues/279#issuecomment-419404197