### PR TITLE
Add special commandline parsing for Windows

### DIFF
--- a/backends/backend.go
+++ b/backends/backend.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os/exec"
 	"reflect"
+	"runtime"
 	"time"
 
 	"github.com/flynn-archive/go-shlex"
@@ -130,7 +131,13 @@ func (b *Backend) ValidateConfigurationFile(context *context.Ctx) (bool, string)
 		return false, err.Error()
 	}
 
-	quotedArgs, err := shlex.Split(b.ValidationParameters)
+	var err error
+	var quotedArgs []string
+	if runtime.GOOS == "windows" {
+		quotedArgs = common.CommandLineToArgv(b.ValidationParameters)
+	} else {
+		quotedArgs, err = shlex.Split(b.ValidationParameters)
+	}
 	if err != nil {
 		log.Errorf("[%s] Error during configuration validation: %s", b.Name, err)
 		return false, err.Error()

--- a/common/exec_helper.go
+++ b/common/exec_helper.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package common
+
+// Dummy function. Only used on Windows
+func CommandLineToArgv(cmd string) []string {
+	panic("not implemented on this platform")
+	return []string{}
+}

--- a/common/exec_helper_windows.go
+++ b/common/exec_helper_windows.go
@@ -1,0 +1,97 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+// extracted from github.com/golang/go/blob/master/src/os/exec_windows.go
+
+package common
+
+// appendBSBytes appends n '\\' bytes to b and returns the resulting slice.
+func appendBSBytes(b []byte, n int) []byte {
+	for ; n > 0; n-- {
+		b = append(b, '\\')
+	}
+	return b
+}
+
+// readNextArg splits command line string cmd into next
+// argument and command line remainder.
+func readNextArg(cmd string) (arg []byte, rest string) {
+	var b []byte
+	var inquote bool
+	var nslash int
+	for ; len(cmd) > 0; cmd = cmd[1:] {
+		c := cmd[0]
+		switch c {
+		case ' ', '\t':
+			if !inquote {
+				return appendBSBytes(b, nslash), cmd[1:]
+			}
+		case '"':
+			b = appendBSBytes(b, nslash/2)
+			if nslash%2 == 0 {
+				// use "Prior to 2008" rule from
+				// http://daviddeley.com/autohotkey/parameters/parameters.htm
+				// section 5.2 to deal with double double quotes
+				if inquote && len(cmd) > 1 && cmd[1] == '"' {
+					b = append(b, c)
+					cmd = cmd[1:]
+				}
+				inquote = !inquote
+			} else {
+				b = append(b, c)
+			}
+			nslash = 0
+			continue
+		case '\\':
+			nslash++
+			continue
+		}
+		b = appendBSBytes(b, nslash)
+		nslash = 0
+		b = append(b, c)
+	}
+	return appendBSBytes(b, nslash), ""
+}
+
+// CommandLineToArgv splits a command line into individual argument
+// strings, following the Windows conventions documented
+// at http://daviddeley.com/autohotkey/parameters/parameters.htm#WINARGV
+func CommandLineToArgv(cmd string) []string {
+	var args []string
+	for len(cmd) > 0 {
+		if cmd[0] == ' ' || cmd[0] == '\t' {
+			cmd = cmd[1:]
+			continue
+		}
+		var arg []byte
+		arg, cmd = readNextArg(cmd)
+		args = append(args, string(arg))
+	}
+	return args
+}


### PR DESCRIPTION
On Windows, commandline parameters are actually passed as one long
string. (They are then parsed the program itself).
Go however, only provides the exec.Command() API, which needs the
arguments split up. (And will later join them again ...)

Import the CommandLineToArgv() version of Go's os/exec_windows
and use it to split Windows commandlines.

Fixes #290