### PR TITLE
Update filebeat and winlogbeat to 6.4.1

### DIFF
--- a/backends/beats/filebeat/render.go
+++ b/backends/beats/filebeat/render.go
@@ -199,7 +199,13 @@ func (fbc *FileBeatConfig) RenderOnChange(response graylog.ResponseCollectorConf
 }
 
 func (fbc *FileBeatConfig) ValidateConfigurationFile() bool {
-	output, err := exec.Command(fbc.ExecPath(), "-configtest", "-c", fbc.ConfigurationPath()).CombinedOutput()
+	var output []byte
+	var err error
+	if fbc.Beats.Version[0] >= 6 {
+		output, err = exec.Command(fbc.ExecPath(), "test", "config", "-c", fbc.ConfigurationPath()).CombinedOutput()
+	} else {
+		output, err = exec.Command(fbc.ExecPath(), "-configtest", "-c", fbc.ConfigurationPath()).CombinedOutput()
+	}
 	soutput := string(output)
 	if err != nil {
 		log.Errorf("[%s] Error during configuration validation: %s", fbc.Name(), soutput)

--- a/backends/beats/winlogbeat/render.go
+++ b/backends/beats/winlogbeat/render.go
@@ -156,7 +156,13 @@ func (wlbc *WinLogBeatConfig) RenderOnChange(response graylog.ResponseCollectorC
 }
 
 func (wlbc *WinLogBeatConfig) ValidateConfigurationFile() bool {
-	output, err := exec.Command(wlbc.ExecPath(), "-configtest", "-c", wlbc.ConfigurationPath()).CombinedOutput()
+	var output []byte
+	var err error
+	if wlbc.Beats.Version[0] >= 6 {
+		output, err = exec.Command(wlbc.ExecPath(), "test", "config", "-c", wlbc.ConfigurationPath()).CombinedOutput()
+	} else {
+		output, err = exec.Command(wlbc.ExecPath(), "-configtest", "-c", wlbc.ConfigurationPath()).CombinedOutput()
+	}
 	soutput := string(output)
 	if err != nil {
 		log.Errorf("[%s] Error during configuration validation: %s", wlbc.Name(), soutput)

--- a/dist/fetch_collectors.sh
+++ b/dist/fetch_collectors.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ARCHS=( x86 x86_64 )
-FILEBEAT_VERSION=6.1.2
-WINLOGBEAT_VERSION=6.1.2
+FILEBEAT_VERSION=6.4.1
+WINLOGBEAT_VERSION=6.4.1
 
 # $1: beat name
 # $2: beat operating system


### PR DESCRIPTION
Our bundled filebeat had a memory leak (elastic/beats#6797).

Fixes #283

While here:
 The "-configtest" option is deprecated since Beats 6.0.
 Add a version switch to avoid warning.