### PR TITLE
fix help Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ package-tar: ## Create tar archive for all platforms
 	@tar --transform="s|/build|/graylog-sidecar|" -Pczf dist/pkg/graylog-sidecar-$(COLLECTOR_VERSION)$(COLLECTOR_VERSION_SUFFIX).tar.gz ./build
 
 help:
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | $(AWK) 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | $(AWK) 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .DEFAULT_GOAL := help
 


### PR DESCRIPTION
previously it only printed the string "Makefile" instead of the possible target names
since we don't care about the file name, we make grep not print it, so awk finds the proper target names to print

turns

```
13:28 $ make help
Makefile                       Build sidecar binary for local target system
Makefile                       Build sidecar binary for OSX
Makefile                       Build sidecar binary for Linux 32bit
Makefile                       Build sidecar binary for Linux
Makefile                       Build sidecar binary for Solaris/OmniOS/Illumos
Makefile                       Build sidecar binary for Windows 32bit
Makefile                       Build sidecar binary for Windows
Makefile                       Remove binaries
Makefile                       Run gofmt
Makefile                       Build NXMock for testing sidecar
Makefile                       Create Linux system package for 32bit hosts
Makefile                       Create Linux system package
Makefile                       Create tar archive for all platforms
Makefile                       Create Windows installer
Makefile                       Run tests
```

into
```
13:28 $ make help
build                          Build sidecar binary for local target system
build-darwin                   Build sidecar binary for OSX
build-linux32                  Build sidecar binary for Linux 32bit
build-linux                    Build sidecar binary for Linux
build-solaris                  Build sidecar binary for Solaris/OmniOS/Illumos
build-windows32                Build sidecar binary for Windows 32bit
build-windows                  Build sidecar binary for Windows
clean                          Remove binaries
fmt                            Run gofmt
misc                           Build NXMock for testing sidecar
package-linux32                Create Linux system package for 32bit hosts
package-linux                  Create Linux system package
package-tar                    Create tar archive for all platforms
package-windows                Create Windows installer
test                           Run tests

```