### PR TITLE
Install empty module directory to suppress filebeat warning

### DIFF
--- a/dist/recipe.rb
+++ b/dist/recipe.rb
@@ -25,6 +25,7 @@ class GraylogSidecar < FPM::Cookery::Recipe
   def install
     bin.install 'graylog-sidecar'
     lib('graylog-sidecar').install '../../collectors/filebeat/linux/x86_64/filebeat'
+    lib('graylog-sidecar/module').mkdir
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     var('lib/graylog-sidecar/generated').mkdir
     var('log/graylog-sidecar').mkdir

--- a/dist/recipe32.rb
+++ b/dist/recipe32.rb
@@ -25,6 +25,7 @@ class GraylogSidecar < FPM::Cookery::Recipe
   def install
     bin.install 'graylog-sidecar'
     lib('graylog-sidecar').install '../../collectors/filebeat/linux/x86/filebeat'
+    lib('graylog-sidecar/module').mkdir
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     var('lib/graylog-sidecar/generated').mkdir
     var('log/graylog-sidecar').mkdir


### PR DESCRIPTION
We don't use modules and these errors are harmless,
but less errors are better.

Fixes #303