### PR TITLE
Fail startup if collector configuration dir is not absolute

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -104,6 +104,13 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 	if ctx.UserConfig.CollectorConfigurationDirectory == "" {
 		log.Fatal("No collector configuration directory was configured.")
 	}
+	if !filepath.IsAbs(ctx.UserConfig.CollectorConfigurationDirectory) {
+		log.Fatal("Collector configuration directory must be an absolute path.")
+	}
+	err = os.MkdirAll(ctx.UserConfig.CollectorConfigurationDirectory, 0750)
+	if err != nil {
+		log.Fatal("Failed to create collector configuration directory. ", err)
+	}
 
 	// log_rotation_time
 	if !(ctx.UserConfig.LogRotationTime > 0) {


### PR DESCRIPTION
Also try to create the directory right away.
It's easier to debug if we fail early.

Fixes #309