### PR TITLE
Improve collector validation error messages

### DIFF
--- a/services/periodicals.go
+++ b/services/periodicals.go
@@ -120,8 +120,8 @@ func checkForUpdateAndRestart(httpClient *http.Client, checksums map[string]stri
 
 		if backend.RenderOnChange(backends.Backend{Template: response.Template}, context) {
 			checksums[backendId] = response.Checksum
-			if valid, output := backend.ValidateConfigurationFile(context); !valid {
-				backend.SetStatusLogErrorf("Collector configuration file is not valid, waiting for the next update.")
+			if err, output := backend.ValidateConfigurationFile(context); err != nil {
+				backend.SetStatusLogErrorf(err.Error())
 				if output != "" {
 					log.Errorf("[%s] Validation command output: %s", backend.Name, output)
 					backend.SetVerboseStatus(output)


### PR DESCRIPTION
Change the ValidateConfigurationFile function to return errors instead of a boolean.
This allows for more specific error messages in the user interface.

Fixes #311