### PR TITLE
Fix and improve Windows service handling

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -52,7 +52,7 @@ func NewConfig() *DaemonConfig {
 
 	dc := &DaemonConfig{
 		Name:        "graylog-sidecar",
-		DisplayName: "Graylog collector sidecar",
+		DisplayName: "Graylog Sidecar",
 		Description: "Wrapper service for Graylog controlled collector",
 		Dir:         rootDir,
 		Env:         []string{},
@@ -130,11 +130,18 @@ func (dc *DaemonConfig) SyncWithAssignments(configChecksums map[string]string, c
 			configChecksums[backend.Id] = ""
 		}
 	}
-
-	// add new backends to registry
+	assignedBackends := []*backends.Backend{}
 	for backendId := range assignments.Store.GetAll() {
 		backend := backends.Store.GetBackendById(backendId)
-		if backend != nil && dc.Runner[backend.Id] == nil {
+		if backend != nil {
+			assignedBackends = append(assignedBackends, backend)
+		}
+	}
+	CleanOldServices(assignedBackends)
+
+	// add new backends to registry
+	for _, backend := range assignedBackends {
+		if dc.Runner[backend.Id] == nil {
 			log.Info("Adding process runner for: " + backend.Name)
 			dc.AddRunner(*backend, context)
 		}

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -193,7 +193,13 @@ func (r *ExecRunner) start() error {
 	}
 
 	// setup process environment
-	quotedArgs, err := shlex.Split(r.args)
+	var err error
+	var quotedArgs []string
+	if runtime.GOOS == "windows" {
+		quotedArgs = common.CommandLineToArgv(r.args)
+	} else {
+		quotedArgs, err = shlex.Split(r.args)
+	}
 	if err != nil {
 		return err
 	}

--- a/daemon/svc_helper.go
+++ b/daemon/svc_helper.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package daemon
+
+import (
+	"github.com/Graylog2/collector-sidecar/backends"
+)
+
+// Dummy function. Only used on Windows
+func CleanOldServices(assignedBackends []*backends.Backend) {
+}

--- a/daemon/svc_helper_windows.go
+++ b/daemon/svc_helper_windows.go
@@ -1,0 +1,113 @@
+package daemon
+
+import (
+	"fmt"
+	"github.com/Graylog2/collector-sidecar/backends"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/eventlog"
+	"golang.org/x/sys/windows/svc/mgr"
+	"strings"
+	"time"
+)
+
+func CleanOldServices(assignedBackends []*backends.Backend) {
+	registeredServices, err := getRegisteredServices()
+	if err != nil {
+		log.Warn("Failed to get registered services. Skipping cleanup. ", err)
+		return
+	}
+	for _, service := range registeredServices {
+		if strings.Contains(service, ServiceNamePrefix) {
+			log.Debugf("Found graylog service %s", service)
+			if !serviceIsAssigned(assignedBackends, service) {
+				log.Infof("Removing stale graylog service %s", service)
+				uninstallService(service)
+			}
+		}
+	}
+}
+
+func getRegisteredServices() ([]string, error) {
+	m, err := mgr.Connect()
+	if err != nil {
+		return nil, err
+	}
+	defer m.Disconnect()
+	registeredServices, err := m.ListServices()
+	if err != nil {
+		return nil, err
+	}
+	return registeredServices, nil
+}
+
+func serviceIsAssigned(assignedBackends []*backends.Backend, serviceName string) bool {
+	for _, backend := range assignedBackends {
+		if backend.ServiceType == "svc" && ServiceNamePrefix+backend.Name == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func uninstallService(name string) {
+	log.Infof("Uninstalling service %s", name)
+	stopService(name)
+
+	m, err := mgr.Connect()
+	if err != nil {
+		log.Errorf("Failed to connect to service manager: %v", err)
+		return
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(name)
+	// service exist so we try to uninstall it
+	if err != nil {
+		log.Debugf("Service %s doesn't exist, no uninstall action needed", name)
+		return
+	}
+
+	defer s.Close()
+	err = s.Delete()
+	if err != nil {
+		log.Errorf("Can't delete service %s: %v", name, err)
+	}
+
+	err = eventlog.Remove(s.Name)
+	if err != nil {
+		log.Errorf("RemoveEventLogSource() failed: %s", err)
+	}
+	return
+}
+
+func stopService(serviceName string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("Failed to connect to service manager: %v", err)
+	}
+	defer m.Disconnect()
+
+	ws, err := m.OpenService(serviceName)
+	if err != nil {
+		return fmt.Errorf("Could not access service %s: %v", serviceName, err)
+	}
+	defer ws.Close()
+
+	status, err := ws.Control(svc.Stop)
+	if err != nil {
+		return fmt.Errorf("Could not send stop control: %v", err)
+	}
+
+	timeout := time.Now().Add(10 * time.Second)
+	for status.State != svc.Stopped {
+		if timeout.Before(time.Now()) {
+			return fmt.Errorf("Timeout waiting for service to go to stopped state: %v", err)
+		}
+		time.Sleep(300 * time.Millisecond)
+		status, err = ws.Query()
+		if err != nil {
+			return fmt.Errorf("Could not retrieve service status: %v", err)
+		}
+	}
+	return nil
+}

--- a/glide.lock
+++ b/glide.lock
@@ -32,7 +32,7 @@ imports:
   subpackages:
   - yaml
 - name: golang.org/x/sys
-  version: 833a04a10549a95dc34458c195cbad61bbb6cb4d
+  version: 98c5dad5d1a0e8a73845ecc8897d0bd56586511d
   subpackages:
   - unix
   - windows

--- a/services/control_handler_windows.go
+++ b/services/control_handler_windows.go
@@ -16,10 +16,9 @@
 package services
 
 import (
+	"github.com/Graylog2/collector-sidecar/backends"
+	"github.com/Graylog2/collector-sidecar/daemon"
 	"github.com/kardianos/service"
-
-	"golang.org/x/sys/windows/svc/eventlog"
-	"golang.org/x/sys/windows/svc/mgr"
 )
 
 func ControlHandler(action string) {
@@ -37,35 +36,6 @@ func ControlHandler(action string) {
 }
 
 func cleanupInstalledServices() {
-	// backends are not initialized yet, let's use names directly
-	uninstallService("graylog-collector-nxlog")
-}
-
-func uninstallService(name string) {
-	log.Infof("Uninstalling service %s", name)
-	m, err := mgr.Connect()
-	if err != nil {
-		log.Errorf("Failed to connect to service manager: %v", err)
-	}
-	defer m.Disconnect()
-
-	s, err := m.OpenService(name)
-	// service exist so we try to uninstall it
-	if err != nil {
-		log.Debugf("Service %s doesn't exist, no uninstall action needed", name)
-		return
-	}
-
-	defer s.Close()
-	err = s.Delete()
-	if err != nil {
-		log.Errorf("Can't delete service %s: %v", name, err)
-	}
-
-	err = eventlog.Remove(s.Name)
-	if err != nil {
-		log.Errorf("RemoveEventLogSource() failed: %s", err)
-	}
-
-	return
+	// Cleans all services starting with "graylog-collector-"
+	daemon.CleanOldServices([]*backends.Backend{})
 }


### PR DESCRIPTION
This change addresses several issues how we handle windows
services:
 - Change the DisplayName of the Sidecar itself so it does not conflict
   with old sidecars.
 - If a sidecar backend (aka collector) gets renamed, update the
   DisplayName to avoid a conflict with the existing service.
 - If backends get renamed, or deleted while the sidecar isn't running
   there was no way we could cleanup those.
   Therefore update golang/x/sys to a newer version that supports
   `ListServices()` so we can search for stale registered services
   and clean those.
 - Improve error handling in `ValidateBeforeStart()` which could
   lead to a panic if a service could not be created.

Fixes #319