### PR TITLE
Add Etag caching for UpdateRegistration results

### DIFF
--- a/api/graylog/responses.go
+++ b/api/graylog/responses.go
@@ -22,6 +22,8 @@ type ResponseCollectorRegistration struct {
 	ConfigurationOverride bool                                       `json:"configuration_override"`
 	CollectorActions      []ResponseCollectorAction                  `json:"actions,omitempty"`
 	Assignments           []assignments.ConfigurationAssignment      `json:"assignments,omitempty"`
+	Checksum              string                                     //Etag of the response
+	NotModified           bool
 }
 
 type ResponseCollectorAction struct {
@@ -35,15 +37,9 @@ type ResponseCollectorRegistrationConfiguration struct {
 }
 
 type ResponseBackendList struct {
-	Backends []ResponseCollectorBackend `json:"collectors"`
-	Checksum string                     //Etag of the response
-}
-
-func (r *ResponseBackendList) IsEmpty() bool {
-	if len(r.Backends) == 0 {
-		return true
-	}
-	return false
+	Backends    []ResponseCollectorBackend `json:"collectors"`
+	Checksum    string                     //Etag of the response
+	NotModified bool
 }
 
 type ResponseCollectorBackend struct {
@@ -63,11 +59,5 @@ type ResponseCollectorConfiguration struct {
 	Name            string `json:"name"`
 	Template        string `json:"template"`
 	Checksum        string //Etag of the response
-}
-
-func (r *ResponseCollectorConfiguration) IsEmpty() bool {
-	if len(r.Template) == 0 {
-		return true
-	}
-	return false
+	NotModified     bool
 }

--- a/services/periodicals.go
+++ b/services/periodicals.go
@@ -123,9 +123,9 @@ func checkForUpdateAndRestart(httpClient *http.Client, checksums map[string]stri
 			// etag match, skip file render
 			continue
 		}
+		checksums[backendId] = response.Checksum
 
 		if backend.RenderOnChange(backends.Backend{Template: response.Template}, context) {
-			checksums[backendId] = response.Checksum
 			if err, output := backend.ValidateConfigurationFile(context); err != nil {
 				backend.SetStatusLogErrorf(err.Error())
 				if output != "" {

--- a/services/periodicals.go
+++ b/services/periodicals.go
@@ -40,53 +40,59 @@ func StartPeriodicals(context *context.Ctx) {
 	go func() {
 		configChecksums := make(map[string]string)
 		backendChecksum := ""
+		assignmentChecksum := ""
 		logOnce := true
 		for {
 			time.Sleep(time.Duration(context.UserConfig.UpdateInterval) * time.Second)
 
 			// registration response contains configuration assignments
-			response, err := updateCollectorRegistration(httpClient, context)
+			response, err := updateCollectorRegistration(httpClient, assignmentChecksum, context)
 			if err != nil {
 				continue
 			}
+			assignmentChecksum = response.Checksum
 			// backend list is needed before configuration assignments are updated
-			backendChecksum, err = fetchBackendList(httpClient, backendChecksum, context)
+			backendResponse, err := fetchBackendList(httpClient, backendChecksum, context)
 			if err != nil {
 				continue
 			}
-			assignments.Store.Update(response.Assignments)
-			// create process instances
-			daemon.Daemon.SyncWithAssignments(configChecksums, context)
-			// test for new or updated configurations and start the corresponding collector
-			if assignments.Store.Len() == 0 {
-				if logOnce {
-					log.Info("No configurations assigned to this instance. Skipping configuration request.")
-					logOnce = false
+			backendChecksum = backendResponse.Checksum
+
+			if !response.NotModified || !backendResponse.NotModified {
+				assignments.Store.Update(response.Assignments)
+				// create process instances
+				daemon.Daemon.SyncWithAssignments(configChecksums, context)
+				// test for new or updated configurations and start the corresponding collector
+				if assignments.Store.Len() == 0 {
+					if logOnce {
+						log.Info("No configurations assigned to this instance. Skipping configuration request.")
+						logOnce = false
+					}
+					continue
+				} else {
+					logOnce = true
 				}
-				continue
-			} else {
-				logOnce = true
 			}
 			checkForUpdateAndRestart(httpClient, configChecksums, context)
 		}
 	}()
 }
 
-// report collector status to Graylog server
-func updateCollectorRegistration(httpClient *http.Client, context *context.Ctx) (graylog.ResponseCollectorRegistration, error) {
+// report collector status to Graylog server and receive assignments
+func updateCollectorRegistration(httpClient *http.Client, checksum string, context *context.Ctx) (graylog.ResponseCollectorRegistration, error) {
 	statusRequest := api.NewStatusRequest()
-	return api.UpdateRegistration(httpClient, context, &statusRequest)
+	return api.UpdateRegistration(httpClient, checksum, context, &statusRequest)
 }
 
-func fetchBackendList(httpClient *http.Client, checksum string, ctx *context.Ctx) (string, error) {
+func fetchBackendList(httpClient *http.Client, checksum string, ctx *context.Ctx) (graylog.ResponseBackendList, error) {
 	response, err := api.RequestBackendList(httpClient, checksum, ctx)
 	if err != nil {
 		log.Error("Can't fetch collector list from Graylog API: ", err)
-		return "", err
+		return response, err
 	}
-	if response.IsEmpty() {
+	if response.NotModified {
 		// etag match, skipping all other actions
-		return response.Checksum, nil
+		return response, nil
 	}
 
 	backendList := []backends.Backend{}
@@ -95,7 +101,7 @@ func fetchBackendList(httpClient *http.Client, checksum string, ctx *context.Ctx
 	}
 	backends.Store.Update(backendList)
 
-	return response.Checksum, nil
+	return response, nil
 }
 
 // fetch configuration periodically
@@ -113,7 +119,7 @@ func checkForUpdateAndRestart(httpClient *http.Client, checksums map[string]stri
 			return
 		}
 
-		if response.IsEmpty() {
+		if response.NotModified {
 			// etag match, skip file render
 			continue
 		}


### PR DESCRIPTION
The response to the registration PUT request contains
configuration assignments, which can be cached as well.

Only run the assignment updates if either the backends or the
assignments have changed.

While here, replace `IsEmpty()` with an `NotModified` flag on each
response struct.