### PR TITLE
Fix sidecar crash when using "svc" runner under linux

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -73,6 +73,10 @@ func RegisterBackendRunner(name string, c RunnerCreator) error {
 
 func (dc *DaemonConfig) AddRunner(backend backends.Backend, context *context.Ctx) {
 	var runner Runner
+	if runnerRegistry[backend.ServiceType] == nil {
+		backend.SetStatusLogErrorf("Execution driver %s is not supported on this platform", backend.ServiceType)
+		return
+	}
 	switch backend.ServiceType {
 	case "exec":
 		runner = runnerRegistry["exec"](backend, context)


### PR DESCRIPTION
Avoid calling a nil function in the runnerRegistry.
This error is not reported to the UI.
We do have validations that should prevent this from being configured.
So this is more like a second safety net.