### PR TITLE
Fix configuration parsing of lists

### DIFF
--- a/cfgfile/schema.go
+++ b/cfgfile/schema.go
@@ -41,7 +41,7 @@ node_id: "file:/etc/graylog/sidecar/node-id"
 update_interval: 10
 tls_skip_verify: false
 send_status: true
-list_log_files:
+list_log_files: []
 cache_path: "/var/cache/graylog-sidecar"
 log_path: "/var/log/graylog-sidecar"
 log_rotate_max_file_size: "10MiB"

--- a/context/context.go
+++ b/context/context.go
@@ -40,8 +40,7 @@ type Ctx struct {
 
 func NewContext() *Ctx {
 	return &Ctx{
-		Inventory:  system.NewInventory(),
-		UserConfig: cfgfile.ConfigDefaults(),
+		Inventory: system.NewInventory(),
 	}
 }
 

--- a/sidecar-example.yml
+++ b/sidecar-example.yml
@@ -42,7 +42,7 @@ server_api_token: ""
 #       - "/opt/app/logs"
 #
 # Default: empty list
-#list_log_files:
+#list_log_files: []
 
 # Directory where the sidecar stores internal data.
 #cache_path: "/var/cache/graylog-sidecar"
@@ -67,7 +67,7 @@ server_api_token: ""
 #       - "/opt/collectors/*"
 #
 # Example disable whitelisting:
-#     collector_binaries_whitelist:
+#     collector_binaries_whitelist: []
 #
 # Default:
 # collector_binaries_whitelist:

--- a/sidecar-windows-example.yml
+++ b/sidecar-windows-example.yml
@@ -47,7 +47,7 @@ send_status: <SENDSTATUS>
 #       - "/opt/app/logs"
 #
 # Default: empty list
-#list_log_files:
+#list_log_files: []
 
 # Directory where the sidecar stores internal data.
 #cache_path: "C:\\Program Files\\Graylog\\sidecar\\cache"
@@ -72,7 +72,7 @@ send_status: <SENDSTATUS>
 #       - "C:\\Program Files\\Filebeat\\filebeat.exe"
 #
 # Example disable whitelisting:
-#     collector_binaries_whitelist:
+#     collector_binaries_whitelist: []
 #
 # Default:
 # collector_binaries_whitelist:


### PR DESCRIPTION
Don't use `ucfg.Merge` because this will merge the contents
of two slices by copying them on top of each other.

Use a much simpler approach and just join the configuration
strings together before parsing them.

Fixes #327