### PR TITLE
Improve yaml doc seperator match

### DIFF
--- a/cfgfile/cfgfile.go
+++ b/cfgfile/cfgfile.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -65,7 +66,8 @@ func Read(out interface{}, path string) error {
 	// append configuration, but strip away possible yaml doc separators
 	scanner := bufio.NewScanner(configfile)
 	for scanner.Scan() {
-		if line := scanner.Text(); line != "---" {
+		line := scanner.Text()
+		if match, _ := regexp.Match("^---[ \t]*$", []byte(line)); !match {
 			filecontent = append(filecontent, []byte(line+"\n")...)
 		}
 	}


### PR DESCRIPTION
According to the yaml spec, the seperator can have
"a line break or a sequence of space characters"

Fixes #327