### PR TITLE
Ensure we can reuse a connection

### DIFF
--- a/api/rest/rest.go
+++ b/api/rest/rest.go
@@ -170,6 +170,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	}
 
 	defer func() {
+		io.Copy(ioutil.Discard, resp.Body)
 		if rerr := resp.Body.Close(); err == nil {
 			err = rerr
 		}


### PR DESCRIPTION
In case we don't process the entire response, discard the remaining
body. This allows the http client to reuse an existing connection,
without having to setup a new one. This is even more expensive when
TLS is used. cf https://github.com/google/go-github/pull/317/files