### PR TITLE
Stop setting default node name to graylog-sidecar

### DIFF
--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -208,9 +208,6 @@ Section "Post"
   ${If} $ServerUrl == ""
     StrCpy $ServerUrl "http://127.0.0.1:9000/api"
   ${EndIf}
-  ${If} $NodeName == ""
-    StrCpy $NodeName "graylog-sidecar"
-  ${EndIf}
   ${If} $UpdateInterval == ""
     StrCpy $UpdateInterval "10"
   ${EndIf}


### PR DESCRIPTION
Removed the lines to default the node name to graylog-sidecar. 
The current action doesn't match the documentation.
" The node name of the sidecar. If this is empty, the sidecar will use the hostname of the host it is running on." When installing the setup defaults to graylog-sidecar