### PR TITLE
Remove unused strftime dependency

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
 hash: c4dcc2e4704247f944548da5b113b7f497e0d2e7d7435d18c40177ed955801cd
 updated: 2018-12-20T18:54:30.605617065+01:00
 imports:
-- name: bitbucket.org/tebeka/strftime
-  version: 2194253a23c090a4d5953b152a3c63fb5da4f5a4
 - name: github.com/docker/go-units
   version: 47565b4f722fb6ceae66b95f853feed578a4a51c
 - name: github.com/elastic/go-ucfg

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,6 @@ import:
 - package: github.com/pborman/uuid
 - package: gopkg.in/yaml.v2
 - package: github.com/elastic/go-ucfg
-- package: bitbucket.org/tebeka/strftime
 - package: github.com/elastic/gosigar
 - package: github.com/rifflock/lfshook
 - package: github.com/flynn-archive/go-shlex


### PR DESCRIPTION
It is broken and not used anymore

(cherry picked from commit e13dbd82571088c301eef38cc4654c145121e255)