### PR TITLE
Update filebeat and winlogbeat to 7.6.2

### DIFF
--- a/dist/fetch_collectors.sh
+++ b/dist/fetch_collectors.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ARCHS=( x86 x86_64 )
-FILEBEAT_VERSION=6.4.2
-WINLOGBEAT_VERSION=6.4.2
+FILEBEAT_VERSION=7.6.2
+WINLOGBEAT_VERSION=7.6.2
 
 # $1: beat name
 # $2: beat operating system


### PR DESCRIPTION
Beats <= 6.4.x is EOL since February.

Releasing this should probably coordinated with a backport of this change: https://github.com/Graylog2/graylog2-server/pull/7879