### PR TITLE
Revert #391 to test windows service.

### DIFF
--- a/dist/fetch_collectors.sh
+++ b/dist/fetch_collectors.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ARCHS=( x86 x86_64 )
-FILEBEAT_VERSION=7.6.2
-WINLOGBEAT_VERSION=7.6.2
+FILEBEAT_VERSION=6.4.2
+WINLOGBEAT_VERSION=6.4.2
 
 # $1: beat name
 # $2: beat operating system
@@ -43,4 +43,3 @@ do
   download_beat "filebeat" "windows" ${FILEBEAT_VERSION} ${ARCH}
   download_beat "winlogbeat" "windows" ${WINLOGBEAT_VERSION} ${ARCH}
 done
-


### PR DESCRIPTION
I am seeing two different issues when running the collector on Windows. Sometimes it says:

`Unable to validate configuration, timeout reached`

And sometimes it says:

 `Could not start service: The service did not respond to the start or control request in a timely fashion." `

This PR reverts the version of Beats to a lower version to test if it is the cause of these issues. 