### PR TITLE
Update beats to 7.11.1  (backport to 1.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ package-linux32: ## Create Linux i386 system package
 	fpm-cook -t deb package dist/recipe32.rb
 	fpm-cook -t rpm package dist/recipe32.rb
 
-package-windows: ## Create Windows installer
+package-windows: prepare-package ## Create Windows installer
 	@mkdir -p dist/pkg
 	makensis -DVERSION=$(COLLECTOR_VERSION) -DVERSION_SUFFIX=$(COLLECTOR_VERSION_SUFFIX) -DREVISION=$(COLLECTOR_REVISION) dist/recipe.nsi
 	dist/chocolatey/gensha.sh $(COLLECTOR_VERSION) $(COLLECTOR_REVISION) $(COLLECTOR_VERSION_SUFFIX)

--- a/dist/fetch_collectors.sh
+++ b/dist/fetch_collectors.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ARCHS=( x86 x86_64 )
-FILEBEAT_VERSION=7.6.2
-WINLOGBEAT_VERSION=7.6.2
+FILEBEAT_VERSION=7.11.1
+WINLOGBEAT_VERSION=7.11.1
 
 # $1: beat name
 # $2: beat operating system
@@ -21,7 +21,7 @@ download_beat()
     archive="/tmp/${name}-${version}-${os}-${arch}.zip"
     if [ ! -f $archive ]; then
       echo "==> Downloading ${name}-${version}-${os}-${arch}"
-      curl -o $archive https://artifacts.elastic.co/downloads/beats/${name}/${name}-${version}-${os}-${arch}.zip
+      curl -o $archive https://artifacts.elastic.co/downloads/beats/${name}/${name}-oss-${version}-${os}-${arch}.zip
     fi
     unzip -o -d dist/collectors/${name}/${os}/${arch} $archive
     mv dist/collectors/${name}/${os}/${arch}/${name}-${version}-${os}-${arch}/* dist/collectors/${name}/${os}/${arch}/
@@ -31,7 +31,7 @@ download_beat()
     archive="/tmp/${name}-${version}-${os}-${arch}.tar.gz"
     if [ ! -f $archive ]; then
       echo "==> Downloading ${name}-${version}-${os}-${arch}"
-      curl -o $archive https://artifacts.elastic.co/downloads/beats/${name}/${name}-${version}-${os}-${arch}.tar.gz
+      curl -o $archive https://artifacts.elastic.co/downloads/beats/${name}/${name}-oss-${version}-${os}-${arch}.tar.gz
     fi
     tar -xzf $archive --strip-components=1 -C dist/collectors/${name}/${os}/${arch}
     ;;


### PR DESCRIPTION
- Make sure we ship the OSS version
- Add prepare-package as a dependency for package-windows

(cherry picked from commit ff73bb991e38ca0d4b6115f3cc72767b106ef4bb)