### PR TITLE
Update Windows installer to create module directory.

### DIFF
--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -106,6 +106,7 @@ Section "Install"
   ;These folders are needed at runtime
   CreateDirectory "$INSTDIR\generated"
   CreateDirectory "$INSTDIR\logs"
+  CreateDirectory "$INSTDIR\module"
   SetOutPath "$INSTDIR"
  
   ${If} ${RunningX64}


### PR DESCRIPTION
Update the Windows installer to create a `module` directory for Winlogbeat. 

Fixes #412 
