### PR TITLE
Fix startup issue on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ build-darwin: ## Build sidecar binary for OSX
 	@mkdir -p build/$(COLLECTOR_VERSION)/darwin/amd64
 	GOOS=darwin GOARCH=amd64 $(GO) build $(BUILD_OPTS) -pkgdir $(GOPATH)/go_darwin -v -i -o build/$(COLLECTOR_VERSION)/darwin/amd64/graylog-sidecar
 
-build-freebsd:
+build-freebsd: ## Build sidecar binary for FreeBSD
 	@mkdir -p build/$(COLLECTOR_VERSION)/freebsd/amd64
 	GOOS=freebsd GOARCH=amd64 $(GO) build $(BUILD_OPTS) -pkgdir $(GOPATH)/go_freebsd -v -i -o build/$(COLLECTOR_VERSION)/freebsd/amd64/graylog-sidecar
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ test: ## Run tests
 build: ## Build sidecar binary for local target system
 	$(GO) build $(BUILD_OPTS) -v -i -o graylog-sidecar
 
-# does not include build-darwin as that only runs with homebrew on a Mac
 build-all: build-linux-armv7 build-linux build-linux32 build-windows build-windows32 build-darwin build-freebsd
 
 build-linux: ## Build sidecar binary for Linux

--- a/dist/tools.rb
+++ b/dist/tools.rb
@@ -11,7 +11,7 @@ module FPM
         end
 
         def version
-          data('COLLECTOR_VERSION')
+          data('COLLECTOR_VERSION_MAJOR') + '.' + data('COLLECTOR_VERSION_MINOR') + '.' + data('COLLECTOR_VERSION_PATCH')
         end
 
         def suffix

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,7 @@ require (
 	github.com/elastic/gosigar v0.0.0-20160829190344-2716c1fe855e
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/go-ole/go-ole v1.2.1-0.20161116064658-5e9c030faf78 // indirect
-	github.com/kardianos/osext v0.0.0-20151124170342-10da29423eb9 // indirect
-	github.com/kardianos/service v0.0.0-20161119210648-6d3a0ee7d342
+	github.com/kardianos/service v1.2.1
 	github.com/kr/text v0.2.0 // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,8 @@ github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BMXYYRWT
 github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:rZfgFAXFS/z/lEd6LJmf9HVZ1LkgYiHx5pHhV5DR16M=
 github.com/go-ole/go-ole v1.2.1-0.20161116064658-5e9c030faf78 h1:0afyVEbxVeRz0ioQYn+9oDaeveMBXJi7juWqz2newuY=
 github.com/go-ole/go-ole v1.2.1-0.20161116064658-5e9c030faf78/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
-github.com/kardianos/osext v0.0.0-20151124170342-10da29423eb9 h1:/l57iytyQiCkn2MnhrtYWyo+Rrinngfr20jcqeL6H80=
-github.com/kardianos/osext v0.0.0-20151124170342-10da29423eb9/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
-github.com/kardianos/service v0.0.0-20161119210648-6d3a0ee7d342 h1:qs0Bq3RWs0NIJ1W7DwOabM7pQvivSFCtzTl4puKax9g=
-github.com/kardianos/service v0.0.0-20161119210648-6d3a0ee7d342/go.mod h1:10UU/bEkzh2iEN6aYzbevY7J6p03KO5siTxQWXMEerg=
+github.com/kardianos/service v1.2.1 h1:AYndMsehS+ywIS6RB9KOlcXzteWUzxgMgBymJD7+BYk=
+github.com/kardianos/service v1.2.1/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -39,6 +37,7 @@ github.com/rifflock/lfshook v0.0.0-20161216150210-24f7833daaff/go.mod h1:GEXHk5H
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -19,7 +19,6 @@ pipeline
    {
      GOPATH = '/home/jenkins/go'
      GO15VENDOREXPERIMENT=1
-     SIDECAR_BRANCH = env.CHANGE_ID ? "${CHANGE_BRANCH}" : "${BRANCH_NAME}"
    }
 
     stages
@@ -32,6 +31,11 @@ pipeline
           }
           steps
           {
+             script
+             {
+               env.SIDECAR_BRANCH = env.CHANGE_ID ? "${CHANGE_BRANCH}" : "${BRANCH_NAME}"
+             }
+             echo "Checking out $SIDECAR_BRANCH..."
              checkout([$class: 'GitSCM', branches: [[name: "*/${SIDECAR_BRANCH}"]], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/Graylog2/collector-sidecar.git']]])
 
              sh 'go version'
@@ -56,6 +60,11 @@ pipeline
 
          steps
          {
+            script
+            {
+              env.SIDECAR_BRANCH = env.CHANGE_ID ? "${CHANGE_BRANCH}" : "${BRANCH_NAME}"
+            }
+            echo "Checking out $SIDECAR_BRANCH..."
             checkout([$class: 'GitSCM', branches: [[name: "*/${SIDECAR_BRANCH}"]], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/Graylog2/collector-sidecar.git']]])
             unstash 'build artifacts'
             sh 'make package-all'

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -19,19 +19,20 @@ pipeline
    {
      GOPATH = '/home/jenkins/go'
      GO15VENDOREXPERIMENT=1
+     SIDECAR_BRANCH = env.CHANGE_ID ? "${CHANGE_BRANCH}" : "${BRANCH_NAME}"
    }
 
-   stages
-   {
-      stage('Build')
-      {
-          agent
+    stages
+            {
+                stage('Build')
+                        {
+                            agent
           {
             label 'linux'
           }
           steps
           {
-             checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/Graylog2/collector-sidecar.git']]])
+             checkout([$class: 'GitSCM', branches: [[name: "*/${SIDECAR_BRANCH}"]], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/Graylog2/collector-sidecar.git']]])
 
              sh 'go version'
              sh 'go mod vendor'
@@ -55,7 +56,7 @@ pipeline
 
          steps
          {
-            checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/Graylog2/collector-sidecar.git']]])
+            checkout([$class: 'GitSCM', branches: [[name: "*/${SIDECAR_BRANCH}"]], extensions: [[$class: 'WipeWorkspace']], userRemoteConfigs: [[url: 'https://github.com/Graylog2/collector-sidecar.git']]])
             unstash 'build artifacts'
             sh 'make package-all'
 

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -21,11 +21,11 @@ pipeline
      GO15VENDOREXPERIMENT=1
    }
 
-    stages
-            {
-                stage('Build')
-                        {
-                            agent
+   stages
+   {
+      stage('Build')
+      {
+          agent
           {
             label 'linux'
           }


### PR DESCRIPTION
Fixes an issue where starting sidecar on FreeBSD would fail with the following error:

```
FATA[0000] Operating system is not supported: No service system detected.
```

The issue was caused by the `github.com/kardianos/service` dependency, which doesn't provide support for FreeBSD in the previously used version. 

Updating it to `v1.2.1` fixes the issue.