### PR TITLE
Fix directory existence test on Windows

### DIFF
--- a/common/fs.go
+++ b/common/fs.go
@@ -17,7 +17,6 @@ package common
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/Graylog2/collector-sidecar/logger"
@@ -47,11 +46,11 @@ func IsDir(filePath string) bool {
 
 }
 
-func CreatePathToFile(filepath string) error {
-	dir := path.Dir(filepath)
+func CreatePathToFile(path string) error {
+	dir := filepath.Dir(path)
 	_, err := os.Open(dir)
 	if err != nil {
-		log.Info("Trying to create directory for: ", filepath)
+		log.Info("Trying to create directory for: ", path)
 		err = os.MkdirAll(dir, 0750)
 		if err != nil {
 			log.Error("Not able to create directory path: ", dir)

--- a/common/helper_test.go
+++ b/common/helper_test.go
@@ -64,6 +64,25 @@ func TestGetCollectorIdFromNonExistingFile(t *testing.T) {
 	}
 }
 
+func TestGetCollectorIdFromNonExistingPath(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-node-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	tmpfile := filepath.Join(dir, "subdir", "node-id")
+	result := GetCollectorId("file:/" + tmpfile)
+	match, err := regexp.Match("^[0-9a-f]{8}-", []byte(result))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !match {
+		t.Fail()
+	}
+}
+
 func TestCollectorIdFileNotWritable(t *testing.T) {
 	dir, err := ioutil.TempDir("", "test-node-id")
 	if err != nil {

--- a/common/helper_test.go
+++ b/common/helper_test.go
@@ -64,6 +64,27 @@ func TestGetCollectorIdFromNonExistingFile(t *testing.T) {
 	}
 }
 
+func TestCollectorIdFileNotWritable(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-node-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	nodeIdDir := filepath.Join(dir, "non-writable")
+
+	err = os.MkdirAll(nodeIdDir, 0500)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpfile := filepath.Join(nodeIdDir, "node-id")
+	result := GetCollectorId("file:/" + tmpfile)
+	if result != "" {
+		t.Fatalf("Unwritable node-id file should result in empty node-id")
+	}
+}
+
 func TestEncloseWithWithoutAction(t *testing.T) {
 	content := "/some regex/"
 	result := EncloseWith(content, "/")


### PR DESCRIPTION
The test if a directory exists is currently broken on Windows. This leads to the sidecar not creating the parent directory for the configured node-id file if the directory doesn't exist yet.

This PR fixes that by using `filepath.Dir` instead of `path.Dir`.

Additionally, logging is improved by adding logging for unsuccessful attempts to write to the node-id file.
