### PR TITLE
Set Windows service type to "Automatic (Delayed Start)"

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 		Name:        daemon.Daemon.Name,
 		DisplayName: daemon.Daemon.DisplayName,
 		Description: daemon.Daemon.Description,
+		Option:      services.ServiceOptions(),
 	}
 
 	distributor := daemon.Daemon.NewDistributor()

--- a/services/service_options.go
+++ b/services/service_options.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2020 Graylog, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the Server Side Public License, version 1,
+// as published by MongoDB, Inc.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// Server Side Public License for more details.
+//
+// You should have received a copy of the Server Side Public License
+// along with this program. If not, see
+// <http://www.mongodb.com/licensing/server-side-public-license>.
+
+//go:build !windows
+// +build !windows
+
+package services
+
+import (
+	"github.com/kardianos/service"
+)
+
+func ServiceOptions() service.KeyValue {
+	return service.KeyValue{}
+}

--- a/services/service_options_windows.go
+++ b/services/service_options_windows.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Graylog, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the Server Side Public License, version 1,
+// as published by MongoDB, Inc.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// Server Side Public License for more details.
+//
+// You should have received a copy of the Server Side Public License
+// along with this program. If not, see
+// <http://www.mongodb.com/licensing/server-side-public-license>.
+
+package services
+
+import "github.com/kardianos/service"
+
+func ServiceOptions() service.KeyValue {
+	return service.KeyValue{
+		"DelayedAutoStart":       true,
+		"OnFailure":              "restart",
+		"OnFailureDelayDuration": "2m",
+	}
+}


### PR DESCRIPTION
After a reboot, this will delay service startup a little.

Also, if the service fails after initially running, it will now be restarted after a delay of two minutes.

The goal of this change is to reduce the chance of sporadic startup issues on Windows, that some users have been experiencing.

Resolves #421