### PR TITLE
Don't clear configuration when the fetch request fails

### DIFF
--- a/api/graylog.go
+++ b/api/graylog.go
@@ -110,6 +110,7 @@ func RequestConfiguration(
 		msg := "Fetching configuration failed"
 		system.GlobalStatus.Set(backends.StatusError, msg+": "+err.Error())
 		log.Errorf("[RequestConfiguration] %s: %v", msg, err)
+		return graylog.ResponseCollectorConfiguration{}, err
 	}
 
 	if resp != nil {


### PR DESCRIPTION
When the configuration fetch request failed without an HTTP status code, the sidecar would treat this as a config change and clear its current configuration.

With this change, the failed request won't lead to the invalidation of the current configuration anymore.

Fixes #413 

Reproducing this is a bit tricky because the behaviour can only be triggered when the request to `/api/sidecar/collectors` succeeds, but the subsequent request to `/api/sidecar/configurations/render/*` fails. 
I used [caddy](https://caddyserver.com/) as a proxy server between the sidecar and the Graylog server to selectively let the latter call fail. This is the `Caddyfile` I was using:

```
{
    debug
}

:2016 {

    # alternating every 10 seconds, this will match or not match the configuration fetch request
    @config_fetch {
        path /api/sidecar/configurations/render/*
        expression (int({time.now.unix}) % 20) < 10
    }

    handle @config_fetch {
        abort
    }

    # catch-all
    handle {
        reverse_proxy 127.0.0.1:9000
    }

}
```

Sidecar is run with the following two settings in `sidecar.yml`:

```
server_url: "http://127.0.0.1:2016/api/"
update_interval: 5
```