### PR TITLE
Implement Chocolatey build and refactor pipeline script

### DIFF
--- a/dist/chocolatey/gensha.sh
+++ b/dist/chocolatey/gensha.sh
@@ -11,7 +11,12 @@ else
   COLLECTOR_CHECKSUM=$(sha256sum dist/pkg/graylog_sidecar_installer_${COLLECTOR_VERSION}-${COLLECTOR_REVISION}.exe | cut -d" " -f1)
 fi
 
-sed -i "s/checksum      = '.*'/checksum      = '$COLLECTOR_CHECKSUM'/" dist/chocolatey/tools/chocolateyinstall.ps1
-sed -i "s/url           = '.*'/url           = 'https:\/\/downloads.graylog.org\/releases\/graylog-collector-sidecar\/${COLLECTOR_VERSION}\/graylog_sidecar_installer_${COLLECTOR_VERSION}-${COLLECTOR_REVISION}.exe'/" dist/chocolatey/tools/chocolateyinstall.ps1
+root_url="https://downloads.graylog.org/releases/graylog-collector-sidecar"
+version_url="${root_url}/${COLLECTOR_VERSION}/graylog_sidecar_installer_${COLLECTOR_VERSION}-${COLLECTOR_REVISION}.exe"
+
+sed -e "s,%%CHECKSUM%%,$COLLECTOR_CHECKSUM,g" \
+	-e "s,%%URL%%,$version_url,g" \
+	"dist/chocolatey/tools/chocolateyinstall.ps1.template" \
+	> "dist/chocolatey/tools/chocolateyinstall.ps1"
 
 find dist/pkg -name "graylog_sidecar_installer*.exe" -exec /bin/bash -c "sha256sum {} | cut -d' ' -f1 > {}.sha256.txt" \;

--- a/dist/chocolatey/graylog-sidecar.nuspec
+++ b/dist/chocolatey/graylog-sidecar.nuspec
@@ -5,13 +5,13 @@
     <version>$version$</version>
     <packageSourceUrl>https://github.com/Graylog2/collector-sidecar</packageSourceUrl>
     <title>Graylog Sidecar</title>
-    <authors>juju2112</authors>
+    <authors>graylog-bernd</authors>
     <projectUrl>https://github.com/Graylog2/collector-sidecar</projectUrl>
     <iconUrl>https://rawcdn.githack.com/Graylog2/collector-sidecar/1ec7260410caddfabe4c972f347d0237b2f5f323/images/graylog-icon.svg</iconUrl>
     <licenseUrl>https://github.com/Graylog2/collector-sidecar/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/Graylog2/collector-sidecar</projectSourceUrl>
-    <docsUrl>https://docs.graylog.org/en/latest/pages/sidecar.html</docsUrl>
+    <docsUrl>https://docs.graylog.org/docs/sidecar</docsUrl>
     <bugTrackerUrl>https://github.com/Graylog2/collector-sidecar/issues</bugTrackerUrl>
     <tags>graylog graylog-sidecar log</tags>
     <summary>Manage log collectors through Graylog</summary>
@@ -24,6 +24,6 @@
     <releaseNotes></releaseNotes>
   </metadata>
   <files>
-    <file src="tools/**" target="tools" />
+    <file src="tools/*.ps1" target="tools" />
   </files>
 </package>

--- a/dist/chocolatey/tools/.gitignore
+++ b/dist/chocolatey/tools/.gitignore
@@ -1,0 +1,1 @@
+/chocolateyinstall.ps1

--- a/dist/chocolatey/tools/chocolateyinstall.ps1.template
+++ b/dist/chocolatey/tools/chocolateyinstall.ps1.template
@@ -5,9 +5,9 @@ $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   fileType      = 'EXE'
-  url           = 'https://downloads.graylog.org/releases/graylog-collector-sidecar/1.1.0/graylog_sidecar_installer_1.1.0-1.exe'
+  url           = '%%URL%%'
   softwareName  = 'graylog-sidecar*'
-  checksum      = '08ee296fa6970fec2026d5956bdfcf9eb622dba92c8e5f811ddf3a765041b810'
+  checksum      = '%%CHECKSUM%%'
   checksumType  = 'sha256'
   silentArgs   = '/S'
 }

--- a/docker/Dockerfile.chocolatey
+++ b/docker/Dockerfile.chocolatey
@@ -1,0 +1,9 @@
+FROM chocolatey/choco:v1.1.0
+
+# The choco binary wants to write to /opt/chocolatey and Jenkins is running
+# the container as non-root user.
+RUN chmod 777 /opt/chocolatey
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y make \
+    && apt-get clean


### PR DESCRIPTION
The build now creates a Chocolatey .nupkg file on every build and
publishes the file when building a release.

Refactor the pipeline script to run all stages on the same node. This
ensures that all stages have access to the build artifacts and we don't
have to stash/unstash the files for each stage.

Additional changes:

- Update "graylog-sidecar.nuspec" file with latest URLs and author
  information
- Generate the "chocolateyinstall.ps1" file from a template for every
  build instead of overwriting the file for each release.
- Apply consistent formatting for the pipeline script