### PR TITLE
Make validation timeout configurable (#435)

### DIFF
--- a/backends/backend.go
+++ b/backends/backend.go
@@ -168,12 +168,12 @@ func (b *Backend) ValidateConfigurationFile(context *context.Ctx) (error, string
 	}()
 
 	select {
-	case <-time.After(time.Duration(30) * time.Second):
+	case <-time.After(context.UserConfig.CollectorValidationTimeout):
 		if err := cmd.Process.Kill(); err != nil {
 			err = fmt.Errorf("Failed to kill validation process: %s", err)
 			return err, ""
 		}
-		return fmt.Errorf("Unable to validate configuration, timeout reached."), ""
+		return fmt.Errorf("Unable to validate configuration, timeout <%v> reached", context.UserConfig.CollectorValidationTimeout), ""
 	case err := <-done:
 		if err != nil {
 			close(done)

--- a/cfgfile/schema.go
+++ b/cfgfile/schema.go
@@ -15,23 +15,27 @@
 
 package cfgfile
 
+import "time"
+
 type SidecarConfig struct {
-	ServerUrl                       string   `config:"server_url"`
-	ServerApiToken                  string   `config:"server_api_token"`
-	TlsSkipVerify                   bool     `config:"tls_skip_verify"`
-	NodeName                        string   `config:"node_name"`
-	NodeId                          string   `config:"node_id"`
-	CachePath                       string   `config:"cache_path"`
-	LogPath                         string   `config:"log_path"`
-	CollectorConfigurationDirectory string   `config:"collector_configuration_directory"`
-	LogRotateMaxFileSizeString      string   `config:"log_rotate_max_file_size"`
-	LogRotateMaxFileSize            int64    // set from LogRotateMaxFileSizeString
-	LogRotateKeepFiles              int      `config:"log_rotate_keep_files"`
-	UpdateInterval                  int      `config:"update_interval"`
-	SendStatus                      bool     `config:"send_status"`
-	ListLogFiles                    []string `config:"list_log_files"`
-	CollectorBinariesWhitelist      []string `config:"collector_binaries_whitelist"`
-	CollectorBinariesAccesslist     []string `config:"collector_binaries_accesslist"`
+	ServerUrl                        string        `config:"server_url"`
+	ServerApiToken                   string        `config:"server_api_token"`
+	TlsSkipVerify                    bool          `config:"tls_skip_verify"`
+	NodeName                         string        `config:"node_name"`
+	NodeId                           string        `config:"node_id"`
+	CachePath                        string        `config:"cache_path"`
+	LogPath                          string        `config:"log_path"`
+	CollectorValidationTimeoutString string        `config:"collector_validation_timeout"`
+	CollectorValidationTimeout       time.Duration // set from CollectorValidationTimeoutString
+	CollectorConfigurationDirectory  string        `config:"collector_configuration_directory"`
+	LogRotateMaxFileSizeString       string        `config:"log_rotate_max_file_size"`
+	LogRotateMaxFileSize             int64         // set from LogRotateMaxFileSizeString
+	LogRotateKeepFiles               int           `config:"log_rotate_keep_files"`
+	UpdateInterval                   int           `config:"update_interval"`
+	SendStatus                       bool          `config:"send_status"`
+	ListLogFiles                     []string      `config:"list_log_files"`
+	CollectorBinariesWhitelist       []string      `config:"collector_binaries_whitelist"`
+	CollectorBinariesAccesslist      []string      `config:"collector_binaries_accesslist"`
 }
 
 // Default Sidecar configuration
@@ -47,6 +51,7 @@ cache_path: "/var/cache/graylog-sidecar"
 log_path: "/var/log/graylog-sidecar"
 log_rotate_max_file_size: "10MiB"
 log_rotate_keep_files: 10
+collector_validation_timeout: "1m"
 collector_configuration_directory: "/var/lib/graylog-sidecar/generated"
 collector_binaries_accesslist:
   - "/usr/bin/filebeat"

--- a/context/context.go
+++ b/context/context.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/Graylog2/collector-sidecar/cfgfile"
 	"github.com/Graylog2/collector-sidecar/common"
@@ -99,6 +100,15 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 	// log_path
 	if ctx.UserConfig.LogPath == "" {
 		log.Fatal("No log directory was configured.")
+	}
+
+	// collector_validation_timeout
+	if ctx.UserConfig.CollectorValidationTimeoutString == "" {
+		log.Fatal("No collector validation timeout was configured.")
+	}
+	ctx.UserConfig.CollectorValidationTimeout, err = time.ParseDuration(ctx.UserConfig.CollectorValidationTimeoutString)
+	if err != nil {
+		log.Fatal("Cannot parse validation timeout duration: ", err)
 	}
 
 	// collector_configuration_directory

--- a/sidecar-example.yml
+++ b/sidecar-example.yml
@@ -56,6 +56,9 @@ server_api_token: ""
 # The maximum number of old log files to retain.
 #log_rotate_keep_files: 10
 
+# How long to wait for the config validation command.
+#collector_validation_timeout: "1m"
+
 # Directory where the sidecar generates configurations for collectors.
 #collector_configuration_directory: "/var/lib/graylog-sidecar/generated"
 

--- a/sidecar-windows-example.yml
+++ b/sidecar-windows-example.yml
@@ -61,6 +61,9 @@ send_status: <SENDSTATUS>
 # The maximum number of old log files to retain.
 #log_rotate_keep_files: 10
 
+# How long to wait for the config validation command.
+#collector_validation_timeout: "1m"
+
 # Directory where the sidecar generates configurations for collectors.
 #collector_configuration_directory: "C:\\Program Files\\Graylog\\sidecar\\generated"
 


### PR DESCRIPTION
Intoduce a new config option: `collector_validation_timeout = 1m`
Also increase the default timeout from 30s to 1m
since 30s seems to low for some use cases.

Fixes #431

(cherry picked from commit 56bd1531a6655ed3d783fa38be8b6ecc30a65011)


