### PR TITLE
Fix combined status

### DIFF
--- a/api/graylog.go
+++ b/api/graylog.go
@@ -276,14 +276,12 @@ func NewStatusRequest() graylog.StatusRequest {
 		}
 	}
 
-	switch {
-	default:
-		combinedStatus = backends.StatusRunning
-	case stoppedCount != 0:
-		combinedStatus = backends.StatusStopped
-		fallthrough
-	case errorCount != 0:
+	if errorCount != 0 {
 		combinedStatus = backends.StatusError
+	} else if stoppedCount != 0 {
+		combinedStatus = backends.StatusStopped
+	} else {
+		combinedStatus = backends.StatusRunning
 	}
 
 	statusMessage := strconv.Itoa(runningCount) + " running / " +


### PR DESCRIPTION
Fixes #439 

Correctly calculate the combined status for a sidecar by using the worst status of any collector. This was probably the original intention, but the used switch statement was handling the "stopped" case wrong.