### PR TITLE
Add "tags" field to configuration and registration request

### DIFF
--- a/api/graylog.go
+++ b/api/graylog.go
@@ -145,6 +145,8 @@ func UpdateRegistration(httpClient *http.Client, checksum string, ctx *context.C
 
 	registration.NodeName = ctx.UserConfig.NodeName
 	registration.NodeDetails.OperatingSystem = common.GetSystemName()
+	registration.NodeDetails.Tags = ctx.UserConfig.Tags
+
 	if ctx.UserConfig.SendStatus {
 		metrics := &graylog.MetricsRequest{
 			Disks75: common.GetFileSystemList75(),

--- a/api/graylog/requests.go
+++ b/api/graylog/requests.go
@@ -30,6 +30,7 @@ type NodeDetailsRequest struct {
 	LogFileList     []common.File   `json:"log_file_list,omitempty"`
 	Metrics         *MetricsRequest `json:"metrics,omitempty"`
 	Status          *StatusRequest  `json:"status,omitempty"`
+	Tags            []string        `json:"tags,omitempty"`
 }
 
 type StatusRequestBackend struct {

--- a/cfgfile/schema.go
+++ b/cfgfile/schema.go
@@ -36,6 +36,7 @@ type SidecarConfig struct {
 	ListLogFiles                     []string      `config:"list_log_files"`
 	CollectorBinariesWhitelist       []string      `config:"collector_binaries_whitelist"`
 	CollectorBinariesAccesslist      []string      `config:"collector_binaries_accesslist"`
+	Tags                             []string      `config:"tags"`
 }
 
 // Default Sidecar configuration
@@ -68,6 +69,7 @@ collector_binaries_accesslist:
   - "/usr/share/journalbeat/bin/journalbeat"
   - "/usr/bin/nxlog"
   - "/opt/nxlog/bin/nxlog"
+tags: []
 `
 
 // Windows specific options. Gets merged over `CommonDefaults`

--- a/sidecar-example.yml
+++ b/sidecar-example.yml
@@ -62,6 +62,13 @@ server_api_token: ""
 # Directory where the sidecar generates configurations for collectors.
 #collector_configuration_directory: "/var/lib/graylog-sidecar/generated"
 
+# A list of tags to assign to this sidecar. Collector configuration matching any of these tags will automatically be
+# applied to the sidecar.
+# Example:
+#    tags:
+#    - apache-logs
+#    - dns-logs
+
 # A list of binaries which are allowed to be executed by the Sidecar. An empty list disables the access list feature.
 # Wildcards can be used, for a full pattern description see https://golang.org/pkg/path/filepath/#Match
 # Example:


### PR DESCRIPTION
Adds a configuration option to assign tags to a sidecar.

Tags configured in `sidecar.yml` are sent to the server where they can be used to apply matching configuration automatically. This PR just adds support to configure and send the tags attribute. The heavy lifting will be done on the server.
