### PR TITLE
Fix version check for Graylog 5 and beyond

### DIFF
--- a/api/version.go
+++ b/api/version.go
@@ -16,10 +16,10 @@ func NewGraylogVersion(v string) (*GraylogVersion, error) {
 
 func (v *GraylogVersion) SupportsMultipleBackends() bool {
 	// cannot use version.Constraints because of a bug in comparing pre-releases
-	return v.Version.Segments()[0] >= 4 && v.Version.Segments()[1] >= 4
+	return (v.Version.Segments()[0] == 4 && v.Version.Segments()[1] >= 4) || v.Version.Segments()[0] >= 5
 }
 
 func (v *GraylogVersion) SupportsExtendedNodeDetails() bool {
 	// cannot use version.Constraints because of a bug in comparing pre-releases
-	return v.Version.Segments()[0] >= 4 && v.Version.Segments()[1] >= 4
+	return (v.Version.Segments()[0] == 4 && v.Version.Segments()[1] >= 4) || v.Version.Segments()[0] >= 5
 }


### PR DESCRIPTION
How did I miss this? :roll_eyes: 



