### PR TITLE
Add upgrade support and improve windows installer

### DIFF
--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -50,6 +50,8 @@
   Var TlsSkipVerify
   Var ParamSendStatus
   Var ParamApiToken
+  Var ParamNodeId
+  Var NodeId
   Var SendStatus
   Var Dialog
   Var Label
@@ -220,6 +222,7 @@ Section "Post"
   ${GetOptions} $Params " -TLS_SKIP_VERIFY=" $ParamTlsSkipVerify
   ${GetOptions} $Params " -SEND_STATUS=" $ParamSendStatus
   ${GetOptions} $Params " -APITOKEN=" $ParamApiToken
+  ${GetOptions} $Params " -NODEID=" $ParamNodeId
 
   ${If} $ParamServerUrl != ""
     StrCpy $ServerUrl $ParamServerUrl
@@ -239,6 +242,9 @@ Section "Post"
   ${If} $ParamApiToken != ""
     StrCpy $ApiToken $ParamApiToken
   ${EndIf}
+  ${If} $ParamNodeId != ""
+    StrCpy $NodeId $ParamNodeId
+  ${EndIf}
 
   ; set defaults
   ${If} $ServerUrl == ""
@@ -253,6 +259,10 @@ Section "Post"
   ${If} $SendStatus == ""
     StrCpy $SendStatus "true"
   ${EndIf}
+  ${If} $NodeId == ""
+    ;sidecar.yml needs double escapes
+    ${WordReplace} "file:$INSTDIR\node-id" "\" "\\" "+" $NodeId
+  ${EndIf}
 
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<SERVERURL>" $ServerUrl
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<NODENAME>" $NodeName
@@ -260,6 +270,7 @@ Section "Post"
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<TLSSKIPVERIFY>" $TlsSkipVerify
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<SENDSTATUS>" $SendStatus
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<APITOKEN>" $ApiToken
+  !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<NODEID>" $NodeId
 
   FileClose $LogFile
 SectionEnd

--- a/sidecar-windows-example.yml
+++ b/sidecar-windows-example.yml
@@ -16,7 +16,7 @@ server_api_token: "<APITOKEN>"
 # ATTENTION: Every sidecar instance needs a unique ID!
 #
 # Default: "file:C:\\Program Files\\Graylog\\sidecar\\node-id"
-node_id: "file:C:\\Program Files\\Graylog\\sidecar\\node-id"
+node_id: "<NODEID>"
 
 # The node name of the sidecar. If this is empty, the sidecar will use the
 # hostname of the host it is running on.


### PR DESCRIPTION
The installer can now also upgrade existing sidcar installations.
    It detects this by the presence of an existing sidecar.yml config.
    In upgrade mode it skip the configuration page.

Additionally the installer will now also register the sidecar
    service automatically. Making this extra command line step obsolete.
    
For debugging purposes, we write a installerlog.txt file now.
    
Improve welcome message test to also show the version and mention the
    autmatic upgrade mode.
    
Only replace the winlogbeat and filebeat collector binaries AFTER
    we stopped the sidecar. Otherwise the files might still be locked
    and the upgrade fails.

Suppport `-NODEID param` for silent installer
Also fix default node-id file location for 32-bit installs




Fixes #365 
Fixes #432 