### PR TITLE
Improve process shutdown handling

### DIFF
--- a/api/graylog.go
+++ b/api/graylog.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"github.com/Graylog2/collector-sidecar/helpers"
 	"io"
 	"net/http"
 	"strconv"
@@ -164,7 +165,7 @@ func UpdateRegistration(httpClient *http.Client, checksum string, ctx *context.C
 	registration := graylog.RegistrationRequest{}
 
 	registration.NodeName = ctx.UserConfig.NodeName
-	registration.NodeDetails.OperatingSystem = common.GetSystemName()
+	registration.NodeDetails.OperatingSystem = helpers.GetSystemName()
 
 	if ctx.UserConfig.SendStatus {
 		metrics := &graylog.MetricsRequest{
@@ -172,7 +173,7 @@ func UpdateRegistration(httpClient *http.Client, checksum string, ctx *context.C
 			CpuIdle: common.GetCpuIdle(),
 			Load1:   common.GetLoad1(),
 		}
-		registration.NodeDetails.IP = common.GetHostIP()
+		registration.NodeDetails.IP = helpers.GetHostIP()
 		registration.NodeDetails.Status = status
 		registration.NodeDetails.Metrics = metrics
 		if len(ctx.UserConfig.ListLogFiles) > 0 {

--- a/assignments/assignment.go
+++ b/assignments/assignment.go
@@ -16,7 +16,7 @@
 package assignments
 
 import (
-	"github.com/Graylog2/collector-sidecar/common"
+	"github.com/Graylog2/collector-sidecar/helpers"
 	"reflect"
 )
 
@@ -92,7 +92,7 @@ func (as *assignmentStore) Update(assignments []ConfigurationAssignment) bool {
 
 func (as *assignmentStore) cleanup(validBackendIds []string) {
 	for backendId := range as.assignments {
-		if !common.IsInList(backendId, validBackendIds) {
+		if !helpers.IsInList(backendId, validBackendIds) {
 			delete(as.assignments, backendId)
 		}
 	}

--- a/backends/backend.go
+++ b/backends/backend.go
@@ -18,6 +18,7 @@ package backends
 import (
 	"bytes"
 	"fmt"
+	"github.com/Graylog2/collector-sidecar/helpers"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -27,7 +28,6 @@ import (
 	"github.com/flynn-archive/go-shlex"
 
 	"github.com/Graylog2/collector-sidecar/api/graylog"
-	"github.com/Graylog2/collector-sidecar/common"
 	"github.com/Graylog2/collector-sidecar/context"
 	"github.com/Graylog2/collector-sidecar/system"
 )
@@ -50,7 +50,7 @@ type Backend struct {
 
 func BackendFromResponse(response graylog.ResponseCollectorBackend, configId string, ctx *context.Ctx) *Backend {
 	return &Backend{
-		Enabled:              common.NewTrue(),
+		Enabled:              helpers.NewTrue(),
 		Id:                   response.Id + "-" + configId,
 		CollectorId:          response.Id,
 		ConfigId:             configId,
@@ -74,10 +74,10 @@ func (b *Backend) Equals(a *Backend) bool {
 }
 
 func (b *Backend) EqualSettings(a *Backend) bool {
-	executeParameters, _ := common.Sprintf(
+	executeParameters, _ := helpers.Sprintf(
 		a.ExecuteParameters,
 		a.ConfigurationPath)
-	validationParameters, _ := common.Sprintf(
+	validationParameters, _ := helpers.Sprintf(
 		a.ValidationParameters,
 		a.ConfigurationPath)
 
@@ -104,7 +104,7 @@ func (b *Backend) CheckExecutableAgainstAccesslist(context *context.Ctx) error {
 	if len(context.UserConfig.CollectorBinariesAccesslist) <= 0 {
 		return nil
 	}
-	isListed, err := common.PathMatch(b.ExecutablePath, context.UserConfig.CollectorBinariesAccesslist)
+	isListed, err := helpers.PathMatch(b.ExecutablePath, context.UserConfig.CollectorBinariesAccesslist)
 	if err != nil {
 		return fmt.Errorf("Can not validate binary path: %s", err)
 	}
@@ -121,7 +121,7 @@ func (b *Backend) CheckExecutableAgainstAccesslist(context *context.Ctx) error {
 }
 
 func (b *Backend) CheckConfigPathAgainstAccesslist(context *context.Ctx) bool {
-	configuration, err := common.PathMatch(b.ConfigurationPath, context.UserConfig.CollectorBinariesAccesslist)
+	configuration, err := helpers.PathMatch(b.ConfigurationPath, context.UserConfig.CollectorBinariesAccesslist)
 	if err != nil {
 		log.Errorf("Can not validate configuration path: %s", err)
 		return false
@@ -145,7 +145,7 @@ func (b *Backend) ValidateConfigurationFile(context *context.Ctx) (error, string
 	var err error
 	var quotedArgs []string
 	if runtime.GOOS == "windows" {
-		quotedArgs = common.CommandLineToArgv(b.ValidationParameters)
+		quotedArgs = helpers.CommandLineToArgv(b.ValidationParameters)
 	} else {
 		quotedArgs, err = shlex.Split(b.ValidationParameters)
 	}

--- a/backends/registry.go
+++ b/backends/registry.go
@@ -16,7 +16,7 @@
 package backends
 
 import (
-	"github.com/Graylog2/collector-sidecar/common"
+	"github.com/Graylog2/collector-sidecar/helpers"
 	"github.com/Graylog2/collector-sidecar/logger"
 )
 
@@ -32,13 +32,13 @@ type backendStore struct {
 
 func (bs *backendStore) SetBackend(backend Backend) {
 	bs.backends[backend.Id] = &backend
-	executeParameters, err := common.Sprintf(backend.ExecuteParameters, backend.ConfigurationPath)
+	executeParameters, err := helpers.Sprintf(backend.ExecuteParameters, backend.ConfigurationPath)
 	if err != nil {
 		log.Errorf("Invalid execute parameters, skip adding backend: %s", backend.Name)
 		return
 	}
 	bs.backends[backend.Id].ExecuteParameters = executeParameters
-	validationParameters, err := common.Sprintf(backend.ValidationParameters, backend.ConfigurationPath)
+	validationParameters, err := helpers.Sprintf(backend.ValidationParameters, backend.ConfigurationPath)
 	if err != nil {
 		log.Errorf("Invalid validation parameters, skip adding backend: %s", backend.Name)
 		return
@@ -84,7 +84,7 @@ func (bs *backendStore) Update(backends []Backend) {
 
 func (bs *backendStore) Cleanup(validBackendIds []string) {
 	for _, backend := range bs.backends {
-		if !common.IsInList(backend.Id, validBackendIds) {
+		if !helpers.IsInList(backend.Id, validBackendIds) {
 			log.Debug("Cleaning up backend: " + backend.Name)
 			delete(bs.backends, backend.Id)
 		}

--- a/backends/render.go
+++ b/backends/render.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/Graylog2/collector-sidecar/common"
 	"github.com/Graylog2/collector-sidecar/context"
+	"github.com/Graylog2/collector-sidecar/helpers"
 	"io/ioutil"
 )
 
@@ -27,7 +28,7 @@ func (b *Backend) render() []byte {
 	var result bytes.Buffer
 	result.WriteString(b.Template)
 
-	return common.ConvertLineBreak(result.Bytes())
+	return helpers.ConvertLineBreak(result.Bytes())
 }
 
 func (b *Backend) renderToFile(context *context.Ctx) error {

--- a/cfgfile/schema.go
+++ b/cfgfile/schema.go
@@ -28,6 +28,8 @@ type SidecarConfig struct {
 	CollectorValidationTimeoutString string        `config:"collector_validation_timeout"`
 	CollectorValidationTimeout       time.Duration // set from CollectorValidationTimeoutString
 	CollectorConfigurationDirectory  string        `config:"collector_configuration_directory"`
+	CollectorShutdownTimeoutString   string        `config:"collector_shutdown_timeout"`
+	CollectorShutdownTimeout         time.Duration // set from CollectorShutdownTimeoutString
 	LogRotateMaxFileSizeString       string        `config:"log_rotate_max_file_size"`
 	LogRotateMaxFileSize             int64         // set from LogRotateMaxFileSizeString
 	LogRotateKeepFiles               int           `config:"log_rotate_keep_files"`
@@ -54,6 +56,7 @@ log_path: "/var/log/graylog-sidecar"
 log_rotate_max_file_size: "10MiB"
 log_rotate_keep_files: 10
 collector_validation_timeout: "1m"
+collector_shutdown_timeout: "10s"
 collector_configuration_directory: "/var/lib/graylog-sidecar/generated"
 collector_binaries_accesslist:
   - "/usr/bin/filebeat"

--- a/changelog/unreleased/issue-463-bis.toml
+++ b/changelog/unreleased/issue-463-bis.toml
@@ -1,0 +1,6 @@
+type = "changed"
+message = "Terminate collector processes with SIGTERM instead of SIGHUP"
+
+issues = ["463"]
+pulls = ["462"]
+

--- a/changelog/unreleased/issue-463-bis.toml
+++ b/changelog/unreleased/issue-463-bis.toml
@@ -1,5 +1,5 @@
 type = "changed"
-message = "Terminate collector processes with SIGTERM instead of SIGHUP"
+message = "Terminate collector processes with SIGTERM instead of SIGHUP."
 
 issues = ["463"]
 pulls = ["462"]

--- a/changelog/unreleased/issue-463-quater.toml
+++ b/changelog/unreleased/issue-463-quater.toml
@@ -1,5 +1,5 @@
 type = "added"
-message = "Provide a new configuration option `collector_shutdown_timeout:10s` to determine how long to wait before sending a SIGKILL when shutting down collector processes"
+message = "Provide a new configuration option `collector_shutdown_timeout:10s` to determine how long to wait before sending a SIGKILL when shutting down collector processes."
 
 issues = ["463"]
 pulls = ["462"]

--- a/changelog/unreleased/issue-463-quater.toml
+++ b/changelog/unreleased/issue-463-quater.toml
@@ -1,0 +1,6 @@
+type = "added"
+message = "Provide a new configuration option `collector_shutdown_timeout:10s` to determine how long to wait before sending a SIGKILL when shutting down collector processes"
+
+issues = ["463"]
+pulls = ["462"]
+

--- a/changelog/unreleased/issue-463-ter.toml
+++ b/changelog/unreleased/issue-463-ter.toml
@@ -1,5 +1,5 @@
 type = "changed"
-message = "Terminate collector processes by killing the process group instead of just the PID"
+message = "Terminate collector processes by killing the process group instead of just the PID."
 
 issues = ["463"]
 pulls = ["462"]

--- a/changelog/unreleased/issue-463-ter.toml
+++ b/changelog/unreleased/issue-463-ter.toml
@@ -1,0 +1,6 @@
+type = "changed"
+message = "Terminate collector processes by killing the process group instead of just the PID"
+
+issues = ["463"]
+pulls = ["462"]
+

--- a/changelog/unreleased/issue-463.toml
+++ b/changelog/unreleased/issue-463.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Make collector shutdown handling more resilient to hanging child processes"
+
+issues = ["463"]
+pulls = ["462"]
+

--- a/changelog/unreleased/issue-463.toml
+++ b/changelog/unreleased/issue-463.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Make collector shutdown handling more resilient to hanging child processes"
+message = "Make collector shutdown handling more resilient to hanging child processes."
 
 issues = ["463"]
 pulls = ["462"]

--- a/context/context.go
+++ b/context/context.go
@@ -16,6 +16,8 @@
 package context
 
 import (
+	"github.com/Graylog2/collector-sidecar/common"
+	"github.com/Graylog2/collector-sidecar/helpers"
 	"github.com/docker/go-units"
 	"net/url"
 	"os"
@@ -25,7 +27,6 @@ import (
 	"time"
 
 	"github.com/Graylog2/collector-sidecar/cfgfile"
-	"github.com/Graylog2/collector-sidecar/common"
 	"github.com/Graylog2/collector-sidecar/logger"
 	"github.com/Graylog2/collector-sidecar/system"
 )
@@ -71,7 +72,7 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 	if ctx.UserConfig.NodeId == "" {
 		log.Fatal("No node ID was configured.")
 	}
-	ctx.NodeId = common.GetCollectorId(ctx.UserConfig.NodeId)
+	ctx.NodeId = helpers.GetCollectorId(ctx.UserConfig.NodeId)
 	if ctx.NodeId == "" {
 		log.Fatal("Empty node-id, exiting! Make sure a valid id is configured.")
 	}
@@ -79,7 +80,7 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 	// node_name
 	if ctx.UserConfig.NodeName == "" {
 		log.Info("No node name was configured, falling back to hostname")
-		ctx.UserConfig.NodeName, err = common.GetHostname()
+		ctx.UserConfig.NodeName, err = helpers.GetHostname()
 		if err != nil {
 			log.Fatal("No node name configured and not able to obtain hostname as alternative.")
 		}

--- a/context/context.go
+++ b/context/context.go
@@ -112,6 +112,10 @@ func (ctx *Ctx) LoadConfig(path *string) error {
 	if err != nil {
 		log.Fatal("Cannot parse validation timeout duration: ", err)
 	}
+	ctx.UserConfig.CollectorShutdownTimeout, err = time.ParseDuration(ctx.UserConfig.CollectorShutdownTimeoutString)
+	if err != nil {
+		log.Fatal("Cannot parse shutdown timeout duration: ", err)
+	}
 
 	// collector_configuration_directory
 	if ctx.UserConfig.CollectorConfigurationDirectory == "" {

--- a/daemon/action_handler.go
+++ b/daemon/action_handler.go
@@ -18,7 +18,7 @@ package daemon
 import (
 	"github.com/Graylog2/collector-sidecar/api/graylog"
 	"github.com/Graylog2/collector-sidecar/backends"
-	"github.com/Graylog2/collector-sidecar/common"
+	"github.com/Graylog2/collector-sidecar/helpers"
 )
 
 func HandleCollectorActions(actions []graylog.ResponseCollectorAction) {
@@ -37,7 +37,7 @@ func HandleCollectorActions(actions []graylog.ResponseCollectorAction) {
 			case action.Properties["stop"] == true:
 				stopAction(backend)
 			default:
-				log.Infof("Got unsupported collector command: %s", common.Inspect(action.Properties))
+				log.Infof("Got unsupported collector command: %s", helpers.Inspect(action.Properties))
 			}
 		}
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -18,8 +18,8 @@ package daemon
 import (
 	"github.com/Graylog2/collector-sidecar/assignments"
 	"github.com/Graylog2/collector-sidecar/backends"
-	"github.com/Graylog2/collector-sidecar/common"
 	"github.com/Graylog2/collector-sidecar/context"
+	"github.com/Graylog2/collector-sidecar/helpers"
 	"github.com/Graylog2/collector-sidecar/logger"
 )
 
@@ -45,7 +45,7 @@ func init() {
 }
 
 func NewConfig() *DaemonConfig {
-	rootDir, err := common.GetRootPath()
+	rootDir, err := helpers.GetRootPath()
 	if err != nil {
 		log.Error("Can not access root directory")
 	}

--- a/daemon/distributor.go
+++ b/daemon/distributor.go
@@ -58,7 +58,7 @@ func (dist *Distributor) Stop(s service.Service) error {
 	for _, runner := range Daemon.Runner {
 		limit := 100
 		for timeout := 0; runner.Running() && timeout < limit; timeout++ {
-			time.Sleep(300 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		}
 		if runner.Running() {
 			log.Warnf("[%s] collector failed to exit", runner.Name())

--- a/daemon/distributor.go
+++ b/daemon/distributor.go
@@ -49,19 +49,16 @@ func (dist *Distributor) Start(s service.Service) error {
 	return nil
 }
 
-// stop all backend runner parallel and wait till they are finished
+// stop all backend runners in parallel and wait until they are finished
 func (dist *Distributor) Stop(s service.Service) error {
 	log.Info("Stopping signal distributor")
 	for _, runner := range Daemon.Runner {
 		runner.Shutdown()
 	}
 	for _, runner := range Daemon.Runner {
-		limit := 100
-		for timeout := 0; runner.Running() && timeout < limit; timeout++ {
+		for runner.Running() {
+			log.Debugf("[%s] Waiting for runner to finish", runner.Name())
 			time.Sleep(100 * time.Millisecond)
-		}
-		if runner.Running() {
-			log.Warnf("[%s] collector failed to exit", runner.Name())
 		}
 	}
 	dist.Running = false

--- a/daemon/distributor.go
+++ b/daemon/distributor.go
@@ -56,8 +56,12 @@ func (dist *Distributor) Stop(s service.Service) error {
 		runner.Shutdown()
 	}
 	for _, runner := range Daemon.Runner {
-		for runner.Running() {
+		limit := 100
+		for timeout := 0; runner.Running() && timeout < limit; timeout++ {
 			time.Sleep(300 * time.Millisecond)
+		}
+		if runner.Running() {
+			log.Warnf("[%s] collector failed to exit", runner.Name())
 		}
 	}
 	dist.Running = false

--- a/daemon/exec_helper.go
+++ b/daemon/exec_helper.go
@@ -61,5 +61,6 @@ func KillProcess(r *ExecRunner, timeout time.Duration) {
 		if err != nil {
 			log.Debugf("[%s] Failed to SIGKILL process group %s", r.Name(), err)
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/daemon/exec_helper.go
+++ b/daemon/exec_helper.go
@@ -45,7 +45,7 @@ func KillProcess(r *ExecRunner) {
 	log.Debugf("[%s] SIGTERM process group", r.Name())
 	err := syscall.Kill(-pid, syscall.SIGTERM)
 	if err != nil {
-		log.Warnf("[%s] Failed to SIGTERM process group %s", r.Name(), err)
+		log.Warnf("[%s] Failed to SIGTERM process group: %s", r.Name(), err)
 	}
 
 	limit := r.context.UserConfig.CollectorShutdownTimeout.Milliseconds()
@@ -59,7 +59,7 @@ func KillProcess(r *ExecRunner) {
 		log.Infof("[%s] Still running after SIGTERM. Sending SIGKILL to the process group", r.Name())
 		err := syscall.Kill(-pid, syscall.SIGKILL)
 		if err != nil {
-			log.Warnf("[%s] Failed to SIGKILL process group %s", r.Name(), err)
+			log.Warnf("[%s] Failed to SIGKILL process group: %s", r.Name(), err)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/daemon/exec_helper.go
+++ b/daemon/exec_helper.go
@@ -42,7 +42,7 @@ func KillProcess(r *ExecRunner, timeout time.Duration) {
 
 	// Signal the process group (-pid) instead of just the process. Otherwise, forked child processes
 	// can keep running and cause cmd.Wait to hang.
-	log.Infof("[%s] SIGTERM process group", r.Name())
+	log.Debugf("[%s] SIGTERM process group", r.Name())
 	err := syscall.Kill(-pid, syscall.SIGTERM)
 	if err != nil {
 		log.Infof("[%s] Failed to SIGTERM process group %s", r.Name(), err)
@@ -51,12 +51,12 @@ func KillProcess(r *ExecRunner, timeout time.Duration) {
 	limit := timeout.Milliseconds()
 	tick := 100 * time.Millisecond
 	for t := tick.Milliseconds(); r.Running() && t < limit; t += tick.Milliseconds() {
-		log.Infof("[%s] Waiting for process group to finish (%vms / %vms)", r.Name(), t, limit)
+		log.Debugf("[%s] Waiting for process group to finish (%vms / %vms)", r.Name(), t, limit)
 		time.Sleep(tick)
 	}
 
 	if r.Running() {
-		log.Infof("[%s] SIGKILL process group", r.Name())
+		log.Infof("[%s] Still running after SIGTERM. Sending SIGKILL to the process group", r.Name())
 		err := syscall.Kill(-pid, syscall.SIGKILL)
 		if err != nil {
 			log.Debugf("[%s] Failed to SIGKILL process group %s", r.Name(), err)

--- a/daemon/exec_helper.go
+++ b/daemon/exec_helper.go
@@ -28,7 +28,7 @@ func Setpgid(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-func KillProcess(r *ExecRunner, timeout time.Duration) {
+func KillProcess(r *ExecRunner) {
 	pid := r.cmd.Process.Pid
 
 	if pid == -1 {
@@ -48,7 +48,7 @@ func KillProcess(r *ExecRunner, timeout time.Duration) {
 		log.Infof("[%s] Failed to SIGTERM process group %s", r.Name(), err)
 	}
 
-	limit := timeout.Milliseconds()
+	limit := r.context.UserConfig.CollectorShutdownTimeout.Milliseconds()
 	tick := 100 * time.Millisecond
 	for t := tick.Milliseconds(); r.Running() && t < limit; t += tick.Milliseconds() {
 		log.Debugf("[%s] Waiting for process group to finish (%vms / %vms)", r.Name(), t, limit)

--- a/daemon/exec_helper.go
+++ b/daemon/exec_helper.go
@@ -45,7 +45,7 @@ func KillProcess(r *ExecRunner) {
 	log.Debugf("[%s] SIGTERM process group", r.Name())
 	err := syscall.Kill(-pid, syscall.SIGTERM)
 	if err != nil {
-		log.Infof("[%s] Failed to SIGTERM process group %s", r.Name(), err)
+		log.Warnf("[%s] Failed to SIGTERM process group %s", r.Name(), err)
 	}
 
 	limit := r.context.UserConfig.CollectorShutdownTimeout.Milliseconds()
@@ -59,7 +59,7 @@ func KillProcess(r *ExecRunner) {
 		log.Infof("[%s] Still running after SIGTERM. Sending SIGKILL to the process group", r.Name())
 		err := syscall.Kill(-pid, syscall.SIGKILL)
 		if err != nil {
-			log.Debugf("[%s] Failed to SIGKILL process group %s", r.Name(), err)
+			log.Warnf("[%s] Failed to SIGKILL process group %s", r.Name(), err)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/daemon/exec_helper.go
+++ b/daemon/exec_helper.go
@@ -34,7 +34,7 @@ func KillProcess(r *ExecRunner, proc *os.Process) {
 	if err != nil {
 		log.Debugf("[%s] Failed to HUP process group %s", r.Name(), err)
 	}
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	if r.Running() {
 		err := syscall.Kill(-proc.Pid, syscall.SIGKILL)
 		if err != nil {

--- a/daemon/exec_helper_windows.go
+++ b/daemon/exec_helper_windows.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2020 Graylog, Inc.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the Server Side Public License, version 1,
+// as published by MongoDB, Inc.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// Server Side Public License for more details.
+//
+// You should have received a copy of the Server Side Public License
+// along with this program. If not, see
+// <http://www.mongodb.com/licensing/server-side-public-license>.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// extracted from github.com/golang/go/blob/master/src/os/exec_windows.go
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+)
+
+func Setpgid(cmd *exec.Cmd) {
+	panic("not implemented on this platform")
+}
+func KillProcess(r *ExecRunner, proc *os.Process) {
+	err := proc.Kill()
+	if err != nil {
+		log.Debugf("[%s] Failed to kill process %s", r.Name(), err)
+	}
+}

--- a/daemon/exec_helper_windows.go
+++ b/daemon/exec_helper_windows.go
@@ -52,7 +52,7 @@ import (
 func Setpgid(cmd *exec.Cmd) {
 	// nop on windows
 }
-func KillProcess(r *ExecRunner, _ time.Duration) {
+func KillProcess(r *ExecRunner) {
 	err := r.cmd.Process.Kill()
 	if err != nil {
 		log.Debugf("[%s] Failed to kill process %s", r.Name(), err)

--- a/daemon/exec_helper_windows.go
+++ b/daemon/exec_helper_windows.go
@@ -46,15 +46,14 @@
 package daemon
 
 import (
-	"os"
 	"os/exec"
 )
 
 func Setpgid(cmd *exec.Cmd) {
 	// nop on windows
 }
-func KillProcess(r *ExecRunner, proc *os.Process) {
-	err := proc.Kill()
+func KillProcess(r *ExecRunner, _ time.Duration) {
+	err := r.cmd.Process.Kill()
 	if err != nil {
 		log.Debugf("[%s] Failed to kill process %s", r.Name(), err)
 	}

--- a/daemon/exec_helper_windows.go
+++ b/daemon/exec_helper_windows.go
@@ -51,7 +51,7 @@ import (
 )
 
 func Setpgid(cmd *exec.Cmd) {
-	panic("not implemented on this platform")
+	// nop on windows
 }
 func KillProcess(r *ExecRunner, proc *os.Process) {
 	err := proc.Kill()

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -237,7 +237,7 @@ func (r *ExecRunner) stop() error {
 
 	log.Infof("[%s] Stopping", r.name)
 
-	KillProcess(r, 5*time.Second)
+	KillProcess(r)
 
 	if !r.Running() {
 		r.backend.SetStatus(backends.StatusStopped, "Stopped", "")

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -211,9 +211,7 @@ func (r *ExecRunner) start() error {
 	r.cmd = exec.Command(r.exec, quotedArgs...)
 	r.cmd.Dir = r.daemon.Dir
 	r.cmd.Env = append(os.Environ(), r.daemon.Env...)
-	if runtime.GOOS != "windows" {
-		Setpgid(r.cmd)
-	}
+	Setpgid(r.cmd) // run with a new process group (unix only)
 
 	r.terminate = make(chan error)
 	// start the actual process and don't block
@@ -266,7 +264,7 @@ func (r *ExecRunner) Restart() error {
 func (r *ExecRunner) restart() error {
 	if r.Running() {
 		r.stop()
-		limit := 10
+		limit := 5
 		for timeout := 0; r.Running() && timeout < limit; timeout++ {
 			log.Debugf("[%s] waiting %ds/%ds for process to finish...", r.Name(), timeout, limit)
 			time.Sleep(1 * time.Second)

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -242,6 +242,7 @@ func (r *ExecRunner) stop() error {
 	if !r.Running() {
 		r.backend.SetStatus(backends.StatusStopped, "Stopped", "")
 	} else {
+		log.Warnf("[%s] Failed to be stopped", r.Name())
 		r.backend.SetStatus(backends.StatusError, "Failed to be stopped", "")
 	}
 

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -307,7 +307,7 @@ func (r *ExecRunner) run() {
 		r.setRunning(true)
 		err := r.cmd.Wait()
 		if err != nil {
-			log.Warnf("[%s] Wait() error %s", r.name, err)
+			log.Debugf("[%s] Wait() error %s", r.name, err)
 		}
 		r.setRunning(false)
 	}()

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -244,6 +244,9 @@ func (r *ExecRunner) stop() error {
 	} else {
 		log.Warnf("[%s] Failed to be stopped", r.Name())
 		r.backend.SetStatus(backends.StatusError, "Failed to be stopped", "")
+		// skip the hanging r.cmd.Wait() goroutine
+		r.terminate <- errors.New("timeout")
+		<-r.terminate // wait for termination
 	}
 
 	return nil
@@ -257,11 +260,6 @@ func (r *ExecRunner) Restart() error {
 func (r *ExecRunner) restart() error {
 	if r.Running() {
 		r.stop()
-	}
-	if r.Running() {
-		// skip the hanging r.cmd.Wait() goroutine
-		r.terminate <- errors.New("timeout")
-		<-r.terminate // wait for termination
 	}
 
 	// wipe collector log files after each try

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/flynn-archive/go-shlex"
@@ -238,14 +237,7 @@ func (r *ExecRunner) stop() error {
 
 	log.Infof("[%s] Stopping", r.name)
 
-	// give the chance to cleanup resources
-	if r.cmd.Process != nil && runtime.GOOS != "windows" {
-		r.cmd.Process.Signal(syscall.SIGHUP)
-		time.Sleep(2 * time.Second)
-	}
-
-	// in doubt kill the process
-	KillProcess(r, r.cmd.Process)
+	KillProcess(r, 5*time.Second)
 
 	if !r.Running() {
 		r.backend.SetStatus(backends.StatusStopped, "Stopped", "")

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -257,11 +257,6 @@ func (r *ExecRunner) Restart() error {
 func (r *ExecRunner) restart() error {
 	if r.Running() {
 		r.stop()
-		limit := 5
-		for timeout := 0; r.Running() && timeout < limit; timeout++ {
-			log.Debugf("[%s] waiting %ds/%ds for process to finish...", r.Name(), timeout, limit)
-			time.Sleep(1 * time.Second)
-		}
 	}
 	if r.Running() {
 		// skip the hanging r.cmd.Wait() goroutine

--- a/daemon/exec_runner.go
+++ b/daemon/exec_runner.go
@@ -307,6 +307,7 @@ func (r *ExecRunner) run() {
 		go func(terminate chan error) {
 			err := r.cmd.Wait()
 			terminate <- err
+			<-terminate // read acknowledgement
 		}(r.terminate)
 
 		err := <-r.terminate

--- a/helpers/argv_helper.go
+++ b/helpers/argv_helper.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Graylog, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the Server Side Public License, version 1,
+// as published by MongoDB, Inc.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// Server Side Public License for more details.
+//
+// You should have received a copy of the Server Side Public License
+// along with this program. If not, see
+// <http://www.mongodb.com/licensing/server-side-public-license>.
+
+//go:build !windows
+// +build !windows
+
+package helpers
+
+// Dummy function. Only used on Windows
+func CommandLineToArgv(cmd string) []string {
+	panic("not implemented on this platform")
+	return []string{}
+}

--- a/helpers/argv_helper_windows.go
+++ b/helpers/argv_helper_windows.go
@@ -43,9 +43,8 @@
 
 // extracted from github.com/golang/go/blob/master/src/os/exec_windows.go
 
-package common
+package helpers
 
-// appendBSBytes appends n '\\' bytes to b and returns the resulting slice.
 func appendBSBytes(b []byte, n int) []byte {
 	for ; n > 0; n-- {
 		b = append(b, '\\')

--- a/helpers/helper.go
+++ b/helpers/helper.go
@@ -13,13 +13,15 @@
 // along with this program. If not, see
 // <http://www.mongodb.com/licensing/server-side-public-license>.
 
-package common
+package helpers
 
 import (
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/Graylog2/collector-sidecar/cfgfile"
+	"github.com/Graylog2/collector-sidecar/common"
+	"github.com/Graylog2/collector-sidecar/logger"
 	"github.com/pborman/uuid"
 	"io/ioutil"
 	"net"
@@ -30,6 +32,8 @@ import (
 	"strings"
 	"unicode"
 )
+
+var log = logger.Log()
 
 func GetRootPath() (string, error) {
 	return filepath.Abs("/")
@@ -90,10 +94,10 @@ func GetCollectorId(collectorId string) string {
 }
 
 func idFromFile(filePath string) string {
-	err := FileExists(filePath)
+	err := common.FileExists(filePath)
 	if err != nil {
 		log.Info("node-id file doesn't exist, generating a new one")
-		err = CreatePathToFile(filePath)
+		err = common.CreatePathToFile(filePath)
 		if err == nil {
 			err = ioutil.WriteFile(filePath, []byte(RandomUuid()), 0644)
 			if err != nil {

--- a/helpers/helper_test.go
+++ b/helpers/helper_test.go
@@ -13,7 +13,7 @@
 // along with this program. If not, see
 // <http://www.mongodb.com/licensing/server-side-public-license>.
 
-package common
+package helpers
 
 import (
 	"io/ioutil"

--- a/logger/hooks/hooks.go
+++ b/logger/hooks/hooks.go
@@ -16,13 +16,13 @@
 package hooks
 
 import (
+	"github.com/Graylog2/collector-sidecar/common"
 	"github.com/Graylog2/collector-sidecar/logger"
 	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/rifflock/lfshook"
 
-	"github.com/Graylog2/collector-sidecar/common"
 	"github.com/Graylog2/collector-sidecar/context"
 )
 

--- a/main.go
+++ b/main.go
@@ -120,9 +120,6 @@ func main() {
 	}
 	hooks.AddLogHooks(ctx, log)
 
-	// initialize backends
-	//backendSetup(ctx)
-
 	// start main loop
 	services.StartPeriodicals(ctx)
 	err = s.Run()
@@ -150,19 +147,3 @@ func commandLineSetup() error {
 
 	return nil
 }
-
-//func backendSetup(context *context.Ctx) {
-//	for _, collector := range context.UserConfig.Backends {
-//		backendCreator, err := backends.GetCreator(collector.Name)
-//		if err != nil {
-//			log.Error("Unsupported collector backend found in configuration: " + collector.Name)
-//			continue
-//		}
-//		backend := backendCreator(context)
-//		backends.Store.AddRunner(backend)
-//		if *collector.Enabled == true && backend.ValidatePreconditions() {
-//			log.Debug("Add collector backend: " + backend.Name())
-//			daemon.Daemon.AddRunner(backend, context)
-//		}
-//	}
-//}

--- a/sidecar-example.yml
+++ b/sidecar-example.yml
@@ -59,6 +59,10 @@ server_api_token: ""
 # How long to wait for the config validation command.
 #collector_validation_timeout: "1m"
 
+# How long to wait for the collector to gracefully shutdown.
+# After this timeout the sidecar tries to terminate the collector with SIGKILL
+#collector_shutdown_timeout: "10s"
+
 # Directory where the sidecar generates configurations for collectors.
 #collector_configuration_directory: "/var/lib/graylog-sidecar/generated"
 


### PR DESCRIPTION
There are scenarios in which the sidecar handles stopping / restarting it's forked collectors poorly:

 1. The collector is a wrapper script that forks additional processes
 2. The wrapper script runs the collector with elevated privileges (sudo)

This PR tries to improve handling this as much as possible.

Instead of killing just the forked PID, it also resorts to killing the entire process group.
This should cover case `1`

For case `2` the sidecar can only avoid waiting forever on a process it is not allowed to kill. (lack of permissions)
This is fixed by adjusting the timeout loop and introducing a terminate channel to abort the goroutine that is endlessly wait(2)ing.

The timeout between sending a `SIGTERM` and  `SIGKILL` can be adjusted with a new configration option:
`collector_shutdown_timeout: "10s"`


In addition:
 - improve the status of the backands reporting to Graylog
 - The GetRotatedLog() writers were closed immideatly after creating them.
This had no effect and can be removed.
 - Don't prevent sidecar from shutting down with hanging collectors
