### PR TITLE
Provide -TAGS= support for windows silent installer

### DIFF
--- a/dist/chocolatey/graylog-sidecar.nuspec
+++ b/dist/chocolatey/graylog-sidecar.nuspec
@@ -20,6 +20,11 @@
       To properly configure the sidecar, you'll need to pass in your **server url** and your **api token**.
 
           choco install graylog-sidecar --install-arguments="'-SERVERURL=http://10.0.2.2:9000/api -APITOKEN=yourapitoken'"
+
+      Other optional example parameters are:
+
+          -TAGS=["example","foo"] -NODENAME=mynodename -NODEID=1234 -SENDSTATUS=false -TLSSKIPVERIFY=true -UPDATEINTERVAL=10s
+
     </description>
     <releaseNotes></releaseNotes>
   </metadata>

--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -51,6 +51,8 @@
   Var ParamSendStatus
   Var ParamApiToken
   Var ParamNodeId
+  Var ParamTags
+  Var Tags
   Var NodeId
   Var SendStatus
   Var Dialog
@@ -227,6 +229,7 @@ Section "Post"
   ${GetOptions} $Params " -SEND_STATUS=" $ParamSendStatus
   ${GetOptions} $Params " -APITOKEN=" $ParamApiToken
   ${GetOptions} $Params " -NODEID=" $ParamNodeId
+  ${GetOptions} $Params " -TAGS=" $ParamTags
 
   ${If} $ParamServerUrl != ""
     StrCpy $ServerUrl $ParamServerUrl
@@ -249,6 +252,9 @@ Section "Post"
   ${If} $ParamNodeId != ""
     StrCpy $NodeId $ParamNodeId
   ${EndIf}
+  ${If} $ParamTags != ""
+    StrCpy $Tags $ParamTags
+  ${EndIf}
 
   ; set defaults
   ${If} $ServerUrl == ""
@@ -267,6 +273,9 @@ Section "Post"
     ;sidecar.yml needs double escapes
     ${WordReplace} "file:$INSTDIR\node-id" "\" "\\" "+" $NodeId
   ${EndIf}
+  ${If} $Tags == ""
+    StrCpy $Tags "[]"
+  ${EndIf}
 
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<SERVERURL>" $ServerUrl
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<NODENAME>" $NodeName
@@ -275,6 +284,7 @@ Section "Post"
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<SENDSTATUS>" $SendStatus
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<APITOKEN>" $ApiToken
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<NODEID>" $NodeId
+  !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<TAGS>" $Tags
 
   ;Install sidecar service
   ${If} $IsUpgrade == 'false'

--- a/sidecar-windows-example.yml
+++ b/sidecar-windows-example.yml
@@ -72,6 +72,15 @@ send_status: <SENDSTATUS>
 # Default:
 # windows_drive_range: "CDEFGHIJKLMNOPQRSTUVWXYZ"
 
+# A list of tags to assign to this sidecar. Collector configuration matching any of these tags will automatically be
+# applied to the sidecar.
+# Default: []
+tags: <TAGS>
+# Example:
+#    tags:
+#    - apache-logs
+#    - dns-logs
+
 # A list of binaries which are allowed to be executed by the Sidecar. An empty list disables the access list feature.
 # Wildcards can be used, for a full pattern description see https://golang.org/pkg/path/filepath/#Match
 # Example:


### PR DESCRIPTION
Example usage:

`graylog_sidecar_installer_1.4.0-1.SNAPSHOT.exe /S -APITOKEN=myapitoken -TAGS=["IIS","exchange"]`

Please note that spaces in tags are not supported.

Fixes #460



