### PR TITLE
Match collector_binaries_accesslist case insensitive on windows and MacOS

### DIFF
--- a/changelog/unreleased/issue-364.toml
+++ b/changelog/unreleased/issue-364.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Match collector_binaries_accesslist case insensitive on Windows and MacOS."
+
+issues = ["364"]
+pulls = ["467"]
+

--- a/dist/go.mod
+++ b/dist/go.mod
@@ -1,1 +1,0 @@
-// Ignore sub-tree

--- a/helpers/helper.go
+++ b/helpers/helper.go
@@ -212,7 +212,14 @@ func PathMatch(path string, patternList []string) (PathMatchResult, error) {
 	}
 
 	for _, pattern := range patternList {
-		match, err := filepath.Match(pattern, result.Path)
+		var match bool
+		var err error
+		if runtime.GOOS == "windows" {
+			// ignore case on windows
+			match, err = filepath.Match(strings.ToLower(pattern), strings.ToLower(result.Path))
+		} else {
+			match, err = filepath.Match(pattern, result.Path)
+		}
 		if err != nil {
 			result.Match = false
 			return result, err

--- a/helpers/helper.go
+++ b/helpers/helper.go
@@ -214,8 +214,8 @@ func PathMatch(path string, patternList []string) (PathMatchResult, error) {
 	for _, pattern := range patternList {
 		var match bool
 		var err error
-		if runtime.GOOS == "windows" {
-			// ignore case on windows
+		if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+			// ignore case on windows and MacOS. Both have usually case-insensitive filesystems.
 			match, err = filepath.Match(strings.ToLower(pattern), strings.ToLower(result.Path))
 		} else {
 			match, err = filepath.Match(pattern, result.Path)


### PR DESCRIPTION
Both usually have case-insensitive file systems.

Feels like this should be fixed in go instead:
https://github.com/golang/go/issues/5441

Also remove a stray go.mod file, that causes IJ to throw a warning on startup.

Fixes #364 
