### PR TITLE
Ready-to-use sidecar configurations

### DIFF
--- a/cfgfile/schema.go
+++ b/cfgfile/schema.go
@@ -65,6 +65,8 @@ collector_binaries_accesslist:
   - "/usr/bin/heartbeat"
   - "/usr/bin/auditbeat"
   - "/usr/bin/journalbeat"
+  - "/usr/lib/graylog-sidecar/filebeat"
+  - "/usr/lib/graylog-sidecar/auditbeat"
   - "/usr/share/filebeat/bin/filebeat"
   - "/usr/share/packetbeat/bin/packetbeat"
   - "/usr/share/metricbeat/bin/metricbeat"

--- a/changelog/unreleased/pr-472.toml
+++ b/changelog/unreleased/pr-472.toml
@@ -1,0 +1,6 @@
+type = "added"
+message = "Bundle Filebeat and Auditbeat for Linux. Add default tag to config file."
+
+issues = ["graylog2-server#15570"]
+pulls = ["472"]
+

--- a/dist/fetch_collectors.sh
+++ b/dist/fetch_collectors.sh
@@ -3,6 +3,7 @@
 ARCHS=( x86 x86_64 )
 FILEBEAT_VERSION=7.11.1
 WINLOGBEAT_VERSION=7.11.1
+AUDITBEAT_VERSION=7.11.1
 
 # $1: beat name
 # $2: beat operating system
@@ -40,7 +41,9 @@ download_beat()
 
 for ARCH in "${ARCHS[@]}"
 do
+  download_beat "filebeat" "linux" ${FILEBEAT_VERSION} ${ARCH}
   download_beat "filebeat" "windows" ${FILEBEAT_VERSION} ${ARCH}
   download_beat "winlogbeat" "windows" ${WINLOGBEAT_VERSION} ${ARCH}
+  download_beat "auditbeat" "linux" ${AUDITBEAT_VERSION} ${ARCH}
 done
 

--- a/dist/fetch_collectors.sh
+++ b/dist/fetch_collectors.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-ARCHS=( x86 x86_64 )
-FILEBEAT_VERSION=7.11.1
-WINLOGBEAT_VERSION=7.11.1
-AUDITBEAT_VERSION=7.11.1
+FILEBEAT_VERSION=8.9.0
+FILEBEAT_VERSION_32=7.17.12
+WINLOGBEAT_VERSION=8.9.0
+WINLOGBEAT_VERSION_32=7.17.12
+AUDITBEAT_VERSION=8.9.0
+AUDITBEAT_VERSION_32=7.17.12
 
 # $1: beat name
 # $2: beat operating system
@@ -39,11 +41,15 @@ download_beat()
   esac
 }
 
-for ARCH in "${ARCHS[@]}"
-do
-  download_beat "filebeat" "linux" ${FILEBEAT_VERSION} ${ARCH}
-  download_beat "filebeat" "windows" ${FILEBEAT_VERSION} ${ARCH}
-  download_beat "winlogbeat" "windows" ${WINLOGBEAT_VERSION} ${ARCH}
-  download_beat "auditbeat" "linux" ${AUDITBEAT_VERSION} ${ARCH}
-done
+download_beat "filebeat" "linux" ${FILEBEAT_VERSION} x86_64
+download_beat "filebeat" "linux" ${FILEBEAT_VERSION_32} x86
+
+download_beat "auditbeat" "linux" ${FILEBEAT_VERSION} x86_64
+download_beat "auditbeat" "linux" ${AUDITBEAT_VERSION_32} x86
+
+download_beat "filebeat" "windows" ${FILEBEAT_VERSION} x86_64
+download_beat "filebeat" "windows" ${FILEBEAT_VERSION_32} x86
+
+download_beat "winlogbeat" "windows" ${WINLOGBEAT_VERSION} x86_64
+download_beat "winlogbeat" "windows" ${WINLOGBEAT_VERSION_32} x86
 

--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -1,12 +1,12 @@
 ; -------------------------------
 ; Start
- 
+
   Name "Graylog Sidecar"
   !define MUI_FILE "savefile"
   !define MUI_BRANDINGTEXT "Graylog Sidecar v${VERSION}${VERSION_SUFFIX}"
   CRCCheck On
   SetCompressor "bzip2"
- 
+
   !include "${NSISDIR}\Contrib\Modern UI\System.nsh"
   !include nsDialogs.nsh
   !include LogicLib.nsh
@@ -24,7 +24,7 @@
   VIAddVersionKey "ProductName" "Graylog Sidecar"
   VIAddVersionKey "ProductVersion" "${VERSION}${VERSION_SUFFIX}"
   VIAddVersionKey "LegalCopyright" "Graylog, Inc."
- 
+
 ;---------------------------------
 ;General
 
@@ -64,9 +64,9 @@
 
 
 ;--------------------------------
-;Modern UI Configuration  
-  
-  !define MUI_ICON "graylog.ico"  
+;Modern UI Configuration
+
+  !define MUI_ICON "graylog.ico"
   !define MUI_WELCOMEPAGE_TITLE "Graylog Sidecar ${VERSION}-${REVISION}${SUFFIX} Installation / Upgrade"
   !define MUI_WELCOMEPAGE_TEXT  "This setup is gonna guide you through the installation / upgrade of the Graylog Sidecar.\r\n\r\n \
 		  If an already configured Sidecar is detected ('sidecar.yml' present), it will perform an upgrade.\r\n \r\n\
@@ -78,7 +78,7 @@
   !insertmacro MUI_UNPAGE_CONFIRM
   !insertmacro MUI_UNPAGE_INSTFILES
 
-  
+
   ; Custom Pages
   Page custom nsDialogsPage nsDialogsPageLeave
   Page instfiles
@@ -87,10 +87,10 @@
   !insertmacro MUI_UNPAGE_FINISH
   !define MUI_DIRECTORYPAGE
   !define MUI_ABORTWARNING
- 
+
 ;--------------------------------
 ;Macros
- 
+
   !insertmacro MUI_LANGUAGE "English"
   !insertmacro WordFind
   !insertmacro WordFind2X
@@ -132,11 +132,11 @@
 
 ;--------------------------------
 ;Data
- 
+
   LicenseData "../LICENSE"
 
-;-------------------------------- 
-;Installer Sections     
+;--------------------------------
+;Installer Sections
 Section "Install"
 
   ;These folders are needed at runtime
@@ -144,13 +144,13 @@ Section "Install"
   CreateDirectory "$INSTDIR\logs"
   CreateDirectory "$INSTDIR\module"
   SetOutPath "$INSTDIR"
- 
+
   SetOverwrite off
   File /oname=sidecar.yml "../sidecar-windows-example.yml"
   SetOverwrite on
   File /oname=sidecar.yml.dist "../sidecar-windows-example.yml"
   File "../LICENSE"
-  File "graylog.ico"  
+  File "graylog.ico"
 
   ;Stop service to allow binary upgrade
   !insertmacro _IfKeyExists HKLM "SYSTEM\CurrentControlSet\Services" "graylog-sidecar"
@@ -192,9 +192,9 @@ Section "Install"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
                  "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
-                 "DisplayIcon" "$\"$INSTDIR\graylog.ico$\""				 
+                 "DisplayIcon" "$\"$INSTDIR\graylog.ico$\""
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
-                 "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"				 
+                 "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
                  "DisplayVersion" "${VERSION}${VERSION_SUFFIX}"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
@@ -205,17 +205,17 @@ Section "Install"
                  "Publisher" "Graylog, Inc."
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
                  "HelpLink" "https://www.graylog.org"
-				 
+
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
                  "NoModify" "1"
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
-                 "NoRepair" "1"				 
+                 "NoRepair" "1"
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar" \
                  "EstimatedSize" "25000"
 
 
 SectionEnd
- 
+
 Section "Post"
 
   ; Parse command line options
@@ -274,7 +274,7 @@ Section "Post"
     ${WordReplace} "file:$INSTDIR\node-id" "\" "\\" "+" $NodeId
   ${EndIf}
   ${If} $Tags == ""
-    StrCpy $Tags "[]"
+    StrCpy $Tags "[ default ]"
   ${EndIf}
 
   !insertmacro _ReplaceInFile "$INSTDIR\sidecar.yml" "<SERVERURL>" $ServerUrl
@@ -302,30 +302,30 @@ Section "Post"
   ${LogWrite} "Installer/Upgrader finished."
   FileClose $LogFile
 SectionEnd
- 
-;--------------------------------    
-;Uninstaller Section  
+
+;--------------------------------
+;Uninstaller Section
 Section "Uninstall"
 
   ;Uninstall system service
   ExecWait '"$INSTDIR\graylog-sidecar.exe" -service stop'
   ExecWait '"$INSTDIR\graylog-sidecar.exe" -service uninstall'
- 
+
   ;Delete Files
-  RMDir /r "$INSTDIR\*.*"    
- 
+  RMDir /r "$INSTDIR\*.*"
+
   ;Remove the installation directory
   SetOutPath $TEMP
   RMDir "$INSTDIR"
   RMDir $GraylogDir
- 
-  ;Remove uninstall entries in the registry 
+
+  ;Remove uninstall entries in the registry
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\GraylogSidecar"
 
 SectionEnd
- 
- 
-;--------------------------------    
+
+
+;--------------------------------
 ;Functions
 
 Function .onInit
@@ -338,24 +338,24 @@ Function .onInit
 
   ; check admin rights
   Call CheckAdmin
-  
+
   ; check concurrent un/installations
   Call CheckConcurrent
-    
+
   !insertmacro Check_Upgrade
 FunctionEnd
 
 Function un.oninit
   ; check admin rights
   Call un.CheckAdmin
-  
+
   ; check concurrent un/installations
   Call un.CheckConcurrent
 
   !insertmacro Check_X64
 FunctionEnd
 
- 
+
 
 Function nsDialogsPage
   ${If} $IsUpgrade == 'true'
@@ -364,10 +364,10 @@ Function nsDialogsPage
 
   nsDialogs::Create 1018
 
-  
+
   !insertmacro MUI_HEADER_TEXT "${MUI_BRANDINGTEXT} Configuration" "Here you can check and modify the configuration of this agent"
-  
-  
+
+
   Pop $Dialog
 
   ${If} $Dialog == error

--- a/dist/recipe.rb
+++ b/dist/recipe.rb
@@ -24,6 +24,8 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   def install
     bin.install 'graylog-sidecar'
+    lib('graylog-sidecar').install '../../collectors/filebeat/linux/x86_64/filebeat'
+    lib('graylog-sidecar').install '../../collectors/auditbeat/linux/x86_64/auditbeat'
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     var('lib/graylog-sidecar/generated').mkdir
     var('log/graylog-sidecar').mkdir

--- a/dist/recipe32.rb
+++ b/dist/recipe32.rb
@@ -24,6 +24,8 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   def install
     bin.install 'graylog-sidecar'
+    lib('graylog-sidecar').install '../../collectors/filebeat/linux/x86/filebeat'
+    lib('graylog-sidecar').install '../../collectors/auditbeat/linux/x86/auditbeat'
     etc('graylog/sidecar').install '../../../sidecar-example.yml', 'sidecar.yml'
     var('lib/graylog-sidecar/generated').mkdir
     var('log/graylog-sidecar').mkdir

--- a/sidecar-example.yml
+++ b/sidecar-example.yml
@@ -68,10 +68,8 @@ server_api_token: ""
 
 # A list of tags to assign to this sidecar. Collector configuration matching any of these tags will automatically be
 # applied to the sidecar.
-# Example:
-#    tags:
-#    - apache-logs
-#    - dns-logs
+tags:
+  - default
 
 # A list of binaries which are allowed to be executed by the Sidecar. An empty list disables the access list feature.
 # Wildcards can be used, for a full pattern description see https://golang.org/pkg/path/filepath/#Match
@@ -91,6 +89,8 @@ server_api_token: ""
 #  - "/usr/bin/heartbeat"
 #  - "/usr/bin/auditbeat"
 #  - "/usr/bin/journalbeat"
+#  - "/usr/lib/graylog-sidecar/filebeat"
+#  - "/usr/lib/graylog-sidecar/auditbeat"
 #  - "/usr/share/filebeat/bin/filebeat"
 #  - "/usr/share/packetbeat/bin/packetbeat"
 #  - "/usr/share/metricbeat/bin/metricbeat"


### PR DESCRIPTION
## Notes for Reviewers

- ship Logbeat with Linux x64 & x86
- ship Audit with Linux x64 & x86
- ship sidecar with `default` tag in sidecar.yml


- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

part of Graylog2/graylog2-server#15570
