### PR TITLE
Re-create HTTP connection to Graylog 60 update iterations

### DIFF
--- a/changelog/issue-479.toml
+++ b/changelog/issue-479.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Re-create HTTP connection to Graylog every 60 request loops to detect DNS changes."
+
+issues = ["479"]
+pulls = [""]
+


### PR DESCRIPTION
We are using HTTP keep-alive, which might never pick up any changes to the DNS name of Graylog.

Since there is no parameter in golang's http.Client to do this, simply re-create a new HTTP connection every 60 calls.

Fixes #479 


