### PR TITLE
Don't hardcode config file location on Windows

### DIFF
--- a/changelog/unreleased/pr-506.toml
+++ b/changelog/unreleased/pr-506.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Don't hardcode default config file location on Windows."
+
+pulls = ["506"]

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ var (
 func init() {
 	var configurationPath string
 	if runtime.GOOS == "windows" {
-		configurationPath = filepath.Join(os.Getenv("SystemDrive")+"\\", "Program Files", "graylog", "sidecar", "sidecar.yml")
+		configurationPath = filepath.Join(filepath.Dir(os.Args[0]), "sidecar.yml")
 	} else {
 		configurationPath = filepath.Join("/etc", "graylog", "sidecar", "sidecar.yml")
 	}


### PR DESCRIPTION
Use the binary installation directory as the default location for the config file.

With upcoming packaging changes, the binary could also be installed in the `Program Files (x86)` directory.
