### PR TITLE
Register graylog-sidecar as Windows service via MSI installer

### DIFF
--- a/dist/msi-package.wxs
+++ b/dist/msi-package.wxs
@@ -57,7 +57,6 @@
               <ServiceControl
                 Id='SidecarServiceControl'
                 Name='graylog-sidecar'
-                Start='install'
                 Stop='both'
                 Remove='uninstall'
                 Wait='yes' />

--- a/dist/msi-package.wxs
+++ b/dist/msi-package.wxs
@@ -45,6 +45,22 @@
               <File Id='SidecarLicense'
                 Name='LICENSE'
                 Source='$(var.LicensePath)' />
+              <ServiceInstall
+                Id='SidecarServiceInstall'
+                Name='graylog-sidecar'
+                DisplayName='Graylog Sidecar'
+                Description='Wrapper service for Graylog controlled collector'
+                Type='ownProcess'
+                Start='auto'
+                ErrorControl='normal'
+                Account='LocalSystem' />
+              <ServiceControl
+                Id='SidecarServiceControl'
+                Name='graylog-sidecar'
+                Start='install'
+                Stop='both'
+                Remove='uninstall'
+                Wait='yes' />
             </Component>
             <Component Id='SidecarConfig' Guid='FECCBAFB-C7A7-4570-9A28-172FDB5B0DE1'>
               <!-- We don't install a sidecar.yml file so we don't remove the file when uninstalling the package. -->


### PR DESCRIPTION
## Summary
Adds `ServiceInstall` to the WiX package so the `graylog-sidecar` Windows service is registered automatically during MSI installation, removing the need to manually run `graylog-sidecar.exe -service install` post-install.

The service is configured as auto-start under `LocalSystem` but is **not started during install**, allowing the user to populate `sidecar.yml` before the service runs for the first time.

On uninstall, the service is stopped and removed automatically.

These changes were built and tested locally with no issues.

A future feature should be to input the server URL and API key as a installer parameter, similar to how the EXE installer does.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

