### PR TITLE
Add HTTP/2 PING keepalive to auth.Manager's HTTP client

### DIFF
--- a/changelog/unreleased/pr-TBD-auth-http2-ping.toml
+++ b/changelog/unreleased/pr-TBD-auth-http2-ping.toml
@@ -1,0 +1,7 @@
+# Rename this file to pr-<N>.toml when the PR number is known, and fill
+# `issues = ["..."]` with the paired upstream-issue number.
+type = "a"
+message = "Add HTTP/2 PING keepalive to `auth.Manager`'s HTTP client so half-dead JWKS / enrollment / CSR connections are detected in ~40s instead of waiting for the kernel's ~11-minute TCP keepalive ladder."
+
+issues = [""]
+pulls = [""]

--- a/superv/auth/manager.go
+++ b/superv/auth/manager.go
@@ -78,6 +78,16 @@ func NewManager(logger *zap.Logger, cfg ManagerConfig) *Manager {
 			TLSHandshakeTimeout:   10 * time.Second,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: cfg.InsecureTLS}, //nolint:gosec // Intentionally configurable
 			ExpectContinueTimeout: 1 * time.Second,
+			// HTTP/2 PING-based liveness: send a PING after 30s of idle on a
+			// connection; close the connection if no PONG returns within 10s.
+			// Evicts half-dead HTTP/2 connections (upstream silently dropped,
+			// no RST reaching the client) in ~40s instead of waiting for the
+			// kernel's ~11-min TCP keepalive ladder. Any inbound frame resets
+			// the SendPingTimeout so healthy traffic is unaffected.
+			HTTP2: &http.HTTP2Config{
+				SendPingTimeout: 30 * time.Second,
+				PingTimeout:     10 * time.Second,
+			},
 		}}
 	}
 


### PR DESCRIPTION
Resolves Graylog2/collector#13.

## Summary

- Populates `http.Transport.HTTP2` on `auth.Manager`'s default HTTP client with `SendPingTimeout=30s` and `PingTimeout=10s`
- Half-dead HTTP/2 connections (upstream silently dropped, no RST) are evicted within ~40s instead of waiting for the kernel's ~11-minute TCP keepalive ladder
- Healthy traffic is unaffected — any inbound frame resets the `SendPingTimeout` timer
- A caller-supplied `HTTPClient` in `ManagerConfig` is left untouched

## Test plan

- [ ] `go test ./superv/auth/...` passes
- [ ] Confirm `GODEBUG=http2debug=2` shows `Transport sending health check` at the configured interval against a live Graylog server