### PR TITLE
Fix/credential reset on 401

### DIFF
--- a/changelog/unreleased/pr-547.toml
+++ b/changelog/unreleased/pr-547.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix/credential reset on 401"
+
+issues = ["543"]
+pulls = ["547"]

--- a/changelog/unreleased/pr-TBD-credential-reset-on-401.toml
+++ b/changelog/unreleased/pr-TBD-credential-reset-on-401.toml
@@ -1,7 +1,0 @@
-# Rename this file to pr-<N>.toml when the PR number is known, and fill
-# `issues = ["..."]` with the paired upstream-issue number.
-type = "a"
-message = "Add opt-in `auth.reset_on_auth_rejection` flag (default `false`) that makes the supervisor clear its persisted credentials, instance UID, and own-logs settings and exit with code 1 when the server rejects its cert with HTTP 401 while already enrolled. A subsequent process start (driven by the service manager) triggers a fresh enrollment with a new UID + keypair. Preserves stock log-and-continue semantics when disabled."
-
-issues = [""]
-pulls = [""]

--- a/changelog/unreleased/pr-TBD-credential-reset-on-401.toml
+++ b/changelog/unreleased/pr-TBD-credential-reset-on-401.toml
@@ -1,0 +1,7 @@
+# Rename this file to pr-<N>.toml when the PR number is known, and fill
+# `issues = ["..."]` with the paired upstream-issue number.
+type = "a"
+message = "Add opt-in `auth.reset_on_auth_rejection` flag (default `false`) that makes the supervisor clear its persisted credentials, instance UID, and own-logs settings and exit with code 1 when the server rejects its cert with HTTP 401 while already enrolled. A subsequent process start (driven by the service manager) triggers a fresh enrollment with a new UID + keypair. Preserves stock log-and-continue semantics when disabled."
+
+issues = [""]
+pulls = [""]

--- a/superv/auth/manager.go
+++ b/superv/auth/manager.go
@@ -416,6 +416,21 @@ func (m *Manager) CompleteRenewal(certPEM []byte) error {
 	return nil
 }
 
+// ClearCredentials removes all persisted credentials from disk and clears the
+// in-memory signing key and certificate so the manager is no longer considered
+// enrolled. The encryption key is also removed. Missing files are silently
+// skipped.
+func (m *Manager) ClearCredentials() error {
+	if err := persistence.ClearCredentials(m.keysDir); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.signingKey = nil
+	m.certificate = nil
+	m.mu.Unlock()
+	return nil
+}
+
 // PrepareRenewal creates a CSR for certificate renewal using the existing keys.
 // Unlike PrepareEnrollment, this does not generate new keypairs or validate tokens.
 func (m *Manager) PrepareRenewal(instanceUID string) ([]byte, error) {

--- a/superv/config/types.go
+++ b/superv/config/types.go
@@ -72,13 +72,14 @@ type BackoffConfig struct {
 
 // AuthConfig configures authentication.
 type AuthConfig struct {
-	EnrollmentEndpoint string            `koanf:"enrollment_endpoint"`
-	EnrollmentToken    string            `koanf:"enrollment_token"`
-	EnrollmentHeaders  map[string]string `koanf:"enrollment_headers"`
-	InsecureTLS        bool              `koanf:"insecure_tls"`
-	JWTLifetime        time.Duration     `koanf:"jwt_lifetime"`
-	RenewalFraction    float64           `koanf:"renewal_fraction"`
-	RenewalInterval    time.Duration     `koanf:"renewal_interval"`
+	EnrollmentEndpoint  string            `koanf:"enrollment_endpoint"`
+	EnrollmentToken     string            `koanf:"enrollment_token"`
+	EnrollmentHeaders   map[string]string `koanf:"enrollment_headers"`
+	InsecureTLS         bool              `koanf:"insecure_tls"`
+	JWTLifetime         time.Duration     `koanf:"jwt_lifetime"`
+	RenewalFraction     float64           `koanf:"renewal_fraction"`
+	RenewalInterval     time.Duration     `koanf:"renewal_interval"`
+	ResetOnAuthRejection bool             `koanf:"reset_on_auth_rejection"`
 }
 
 // KeysConfig configures key storage.

--- a/superv/persistence/instance.go
+++ b/superv/persistence/instance.go
@@ -71,6 +71,16 @@ func LoadOrCreateInstanceUID(dir string) (string, error) {
 	return data.InstanceUID, nil
 }
 
+// ClearInstanceUID removes the instance UID file from dir.
+// If the file does not exist the call is a no-op.
+func ClearInstanceUID(dir string) error {
+	path := filepath.Join(dir, instanceUIDFile)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing %s: %w", instanceUIDFile, err)
+	}
+	return nil
+}
+
 // LoadInstanceData loads the instance data from disk.
 func LoadInstanceData(dir string) (*InstanceData, error) {
 	filePath := filepath.Join(dir, instanceUIDFile)

--- a/superv/persistence/keys.go
+++ b/superv/persistence/keys.go
@@ -164,6 +164,18 @@ func CertificateExists(keysDir string) bool {
 	return err == nil
 }
 
+// ClearCredentials removes the signing key, signing certificate, and encryption
+// key files from keysDir. Files that do not exist are silently skipped.
+func ClearCredentials(keysDir string) error {
+	for _, name := range []string{SigningKeyFile, SigningCertFile, encryptionKeyFile} {
+		path := filepath.Join(keysDir, name)
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("removing %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
 // CertificateFingerprint returns the SHA-256 fingerprint of the certificate.
 func CertificateFingerprint(keysDir string) (string, error) {
 	cert, err := LoadCertificate(keysDir)

--- a/superv/supervisor/auth_rejection_test.go
+++ b/superv/supervisor/auth_rejection_test.go
@@ -1,0 +1,168 @@
+// Copyright (C)  2026 Graylog, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the Server Side Public License, version 1,
+// as published by MongoDB, Inc.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// Server Side Public License for more details.
+//
+// You should have received a copy of the Server Side Public License
+// along with this program. If not, see
+// <http://www.mongodb.com/licensing/server-side-public-license>.
+//
+// SPDX-License-Identifier: SSPL-1.0
+
+package supervisor
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/Graylog2/collector-sidecar/superv/auth"
+	"github.com/Graylog2/collector-sidecar/superv/config"
+	"github.com/Graylog2/collector-sidecar/superv/persistence"
+)
+
+// writeStubCredentials places empty signing.key + signing.crt files in
+// keysDir so auth.Manager.IsEnrolled() returns true. The file contents are
+// not parsed by handleAuthRejection — IsEnrolled() is a stat-based check.
+func writeStubCredentials(t *testing.T, keysDir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(keysDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, persistence.SigningKeyFile), []byte("stub"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, persistence.SigningCertFile), []byte("stub"), 0o600))
+}
+
+// newAuthRejectionTestSupervisor constructs a minimal Supervisor whose only
+// wired fields are the ones handleAuthRejection touches: logger, authManager,
+// authCfg, persistenceDir, exitFn. exitFn records the invoked code instead of
+// actually calling os.Exit.
+func newAuthRejectionTestSupervisor(t *testing.T, resetEnabled bool, enrolled bool) (*Supervisor, *int) {
+	t.Helper()
+
+	keysDir := t.TempDir()
+	persistDir := t.TempDir()
+	if enrolled {
+		writeStubCredentials(t, keysDir)
+	}
+
+	authMgr := auth.NewManager(zaptest.NewLogger(t).Named("auth"), auth.ManagerConfig{
+		KeysDir: keysDir,
+	})
+
+	var exitCode int = -1 // -1 = "exit not called"
+	captureExit := func(code int) { exitCode = code }
+
+	s := &Supervisor{
+		logger: zaptest.NewLogger(t),
+		authCfg: config.AuthConfig{
+			ResetOnAuthRejection: resetEnabled,
+		},
+		authManager:    authMgr,
+		persistenceDir: persistDir,
+		exitFn:         captureExit,
+	}
+	return s, &exitCode
+}
+
+// TestHandleAuthRejection_GatedByConfig verifies the 401-while-enrolled
+// recovery path only fires when (a) the error is a 401, (b) the agent is
+// enrolled, and (c) auth.reset_on_auth_rejection is true in configuration.
+func TestHandleAuthRejection_GatedByConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		resetEnabled bool
+		enrolled     bool
+		err          error
+		wantExit     bool
+	}{
+		{
+			name:         "enabled + enrolled + 401 => exit(1)",
+			resetEnabled: true,
+			enrolled:     true,
+			err:          errors.New("invalid response from server: 401"),
+			wantExit:     true,
+		},
+		{
+			name:         "enabled + enrolled + 'unauthorized' substring => exit(1)",
+			resetEnabled: true,
+			enrolled:     true,
+			err:          errors.New("server response code=401 (Unauthorized)"),
+			wantExit:     true,
+		},
+		{
+			name:         "disabled + enrolled + 401 => preserved stock behavior (no exit)",
+			resetEnabled: false,
+			enrolled:     true,
+			err:          errors.New("invalid response from server: 401"),
+			wantExit:     false,
+		},
+		{
+			name:         "enabled + not enrolled + 401 => retry, no exit",
+			resetEnabled: true,
+			enrolled:     false,
+			err:          errors.New("invalid response from server: 401"),
+			wantExit:     false,
+		},
+		{
+			name:         "enabled + enrolled + non-401 error => no exit",
+			resetEnabled: true,
+			enrolled:     true,
+			err:          errors.New("connection reset by peer"),
+			wantExit:     false,
+		},
+		{
+			name:         "nil error => no exit",
+			resetEnabled: true,
+			enrolled:     true,
+			err:          nil,
+			wantExit:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, exitCode := newAuthRejectionTestSupervisor(t, tc.resetEnabled, tc.enrolled)
+			s.handleAuthRejection(tc.err)
+			if tc.wantExit {
+				assert.Equal(t, 1, *exitCode, "exitFn must be called with code 1")
+			} else {
+				assert.Equal(t, -1, *exitCode, "exitFn must NOT be called")
+			}
+		})
+	}
+}
+
+// TestHandleAuthRejection_ClearsPersistentState verifies that when the gate
+// fires, credentials and identity.yaml are removed from disk.
+func TestHandleAuthRejection_ClearsPersistentState(t *testing.T) {
+	s, exitCode := newAuthRejectionTestSupervisor(t, true, true)
+
+	keysDir := s.authManager.GetSigningKeyPath() // returns the path, not the dir
+	keysDir = filepath.Dir(keysDir)
+
+	// Seed identity.yaml so ClearInstanceUID has something to remove.
+	identityPath := filepath.Join(s.persistenceDir, "identity.yaml")
+	require.NoError(t, os.WriteFile(identityPath, []byte("instance_uid: stub\n"), 0o600))
+
+	// Precondition: files exist.
+	require.FileExists(t, filepath.Join(keysDir, persistence.SigningKeyFile))
+	require.FileExists(t, filepath.Join(keysDir, persistence.SigningCertFile))
+	require.FileExists(t, identityPath)
+
+	s.handleAuthRejection(errors.New("invalid response from server: 401"))
+
+	// Postcondition: gate fired (exit called), files removed.
+	assert.Equal(t, 1, *exitCode)
+	assert.NoFileExists(t, filepath.Join(keysDir, persistence.SigningKeyFile))
+	assert.NoFileExists(t, filepath.Join(keysDir, persistence.SigningCertFile))
+	assert.NoFileExists(t, identityPath)
+}

--- a/superv/supervisor/opamp_client.go
+++ b/superv/supervisor/opamp_client.go
@@ -127,6 +127,7 @@ func (s *Supervisor) createOpAMPCallbacks() *opamp.Callbacks {
 		},
 		OnConnectFailed: func(_ context.Context, err error) {
 			s.logger.Error("Failed to connect to OpAMP server", zap.Error(err))
+			s.handleAuthRejection(err)
 		},
 		OnError: func(_ context.Context, err *protobufs.ServerErrorResponse) {
 			s.logger.Error("OpAMP server error", zap.Error(fmt.Errorf("%s: %s", err.GetType(), err.GetErrorMessage())))

--- a/superv/supervisor/supervisor.go
+++ b/superv/supervisor/supervisor.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -44,6 +45,7 @@ import (
 	"github.com/Graylog2/collector-sidecar/superv/keen"
 	"github.com/Graylog2/collector-sidecar/superv/opamp"
 	"github.com/Graylog2/collector-sidecar/superv/ownlogs"
+	"github.com/Graylog2/collector-sidecar/superv/persistence"
 )
 
 const (
@@ -103,6 +105,10 @@ type Supervisor struct {
 	// settings. Defaults to createAndStartClient; overridden in tests for
 	// interleaving control.
 	createClientFunc func(ctx context.Context, settings connection.Settings) (*opamp.Client, error)
+
+	// exitFn is called when the supervisor must terminate. Defaults to os.Exit;
+	// overridden in tests to capture the exit code without actually exiting.
+	exitFn func(int)
 
 	// ownLogsManager manages OTLP export of the supervisor's own logs.
 	ownLogsManager     *ownlogs.Manager
@@ -237,12 +243,50 @@ func New(logger *zap.Logger, cfg config.Config, instanceUID string) (*Supervisor
 		renewalBackoffCfg:         cfg.Server.Connection.RetryBackoff,
 	}
 	s.createClientFunc = s.createAndStartClient
+	s.exitFn = os.Exit
 	return s, nil
 }
 
 // InstanceUID returns the supervisor's unique instance identifier.
 func (s *Supervisor) InstanceUID() string {
 	return s.instanceUID
+}
+
+// handleAuthRejection is called from OnConnectFailed. When the error indicates a
+// 401 Unauthorized response, and the supervisor is already enrolled, and
+// auth.reset_on_auth_rejection is enabled, all persisted credentials are
+// cleared and the process exits so the service manager can trigger a fresh
+// enrollment. The function is a no-op for non-401 errors and for 401s that
+// arrive while enrollment is still in progress.
+func (s *Supervisor) handleAuthRejection(err error) {
+	if err == nil {
+		return
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "401") && !strings.Contains(strings.ToLower(errMsg), "unauthorized") {
+		return
+	}
+	if !s.authManager.IsEnrolled() {
+		s.logger.Warn("Authentication rejected (401) during enrollment; retry will continue")
+		return
+	}
+	if !s.authCfg.ResetOnAuthRejection {
+		s.logger.Warn("Authentication rejected (401) with existing credentials; auth.reset_on_auth_rejection is disabled, so recovery requires manual removal of persisted credentials")
+		return
+	}
+	s.logger.Error("Authentication rejected (401) with existing credentials; clearing credentials, instance UID, and own_logs persistence and exiting to trigger re-enrollment")
+	if clearErr := s.authManager.ClearCredentials(); clearErr != nil {
+		s.logger.Error("Failed to clear credentials before exit", zap.Error(clearErr))
+	}
+	if clearErr := persistence.ClearInstanceUID(s.persistenceDir); clearErr != nil {
+		s.logger.Error("Failed to clear instance UID before exit", zap.Error(clearErr))
+	}
+	if s.ownLogsPersistence != nil {
+		if clearErr := s.ownLogsPersistence.Delete(); clearErr != nil {
+			s.logger.Error("Failed to clear own_logs persistence before exit", zap.Error(clearErr))
+		}
+	}
+	s.exitFn(1)
 }
 
 // expandArgs expands template placeholders in agent args.


### PR DESCRIPTION
## Notes for Reviewers

This PR supercedes PR Graylog2/collector-sidecar#545 to resolve issue https://github.com/Graylog2/collector/issues/14 .

## Summary

- Adds `auth.reset_on_auth_rejection` config flag (default `false`) to `AuthConfig`
- When enabled, a new `handleAuthRejection` method called from `OnConnectFailed` detects 401 on an already-enrolled supervisor and clears all persisted state before exiting with code 1, allowing the service manager to trigger a fresh enrollment
- State cleared on exit: signing key + cert + encryption key (`persistence.ClearCredentials`), instance UID (`persistence.ClearInstanceUID`), own-logs settings (`ownLogsPersistence.Delete`)
- When the flag is `false` (the default), behavior is identical to stock — 401 is logged and polling continues
- `auth.Manager.ClearCredentials()` added as a thin wrapper that removes the key/cert files and drops the in-memory cached credentials so `IsEnrolled()` returns false immediately

## Test plan

- [x] `go test ./superv/supervisor/ -run TestHandleAuthRejection` passes (6 gate scenarios + persistent-state cleanup test)
- [x] Deploy with `reset_on_auth_rejection: true`, delete the server-side collector record via the Graylog API, confirm the supervisor exits on the next 401 and re-enrolls with a fresh UID on restart
- [x] Deploy with `reset_on_auth_rejection: false` (default), confirm 401 is logged and the process keeps running without exiting

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

