### PR TITLE
Fix infinite loop in SvcRunner.restart() and add shutdown timeout

### DIFF
--- a/changelog/unreleased/issue-14264.toml
+++ b/changelog/unreleased/issue-14264.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix infinite loop in Windows service runner restart that could permanently block configuration updates."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14264"]
+pulls = [""]

--- a/changelog/unreleased/issue-14264.toml
+++ b/changelog/unreleased/issue-14264.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Fix infinite loop in Windows service runner restart that could permanently block configuration updates."
 
 issues = ["Graylog2/graylog-plugin-enterprise#14264"]
-pulls = [""]
+pulls = ["554"]

--- a/daemon/distributor.go
+++ b/daemon/distributor.go
@@ -55,8 +55,13 @@ func (dist *Distributor) Stop(s service.Service) error {
 	for _, runner := range Daemon.Runner {
 		runner.Shutdown()
 	}
+	deadline := time.Now().Add(30 * time.Second)
 	for _, runner := range Daemon.Runner {
 		for runner.Running() {
+			if time.Now().After(deadline) {
+				log.Warnf("[%s] Timed out waiting for runner to finish", runner.Name())
+				break
+			}
 			log.Debugf("[%s] Waiting for runner to finish", runner.Name())
 			time.Sleep(100 * time.Millisecond)
 		}

--- a/daemon/distributor.go
+++ b/daemon/distributor.go
@@ -55,8 +55,8 @@ func (dist *Distributor) Stop(s service.Service) error {
 	for _, runner := range Daemon.Runner {
 		runner.Shutdown()
 	}
-	deadline := time.Now().Add(30 * time.Second)
 	for _, runner := range Daemon.Runner {
+		deadline := time.Now().Add(30 * time.Second)
 		for runner.Running() {
 			if time.Now().After(deadline) {
 				log.Warnf("[%s] Timed out waiting for runner to finish", runner.Name())

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -269,7 +269,7 @@ func (r *SvcRunner) restart() error {
 		if err := r.stop(); err != nil {
 			log.Errorf("[%s] Failed to stop: %v", r.Name(), err)
 		}
-		for timeout := 0; r.Running() && timeout < 5; timeout++ {
+		for timeout := 0; r.Running() && timeout < 20; timeout++ {
 			log.Debugf("[%s] waiting for process to finish...", r.Name())
 			time.Sleep(1 * time.Second)
 		}

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -92,7 +92,7 @@ func (r *SvcRunner) Running() bool {
 		return false
 	}
 
-	return status.State == svc.Running
+	return status.State == svc.Running || status.State == svc.StopPending
 }
 
 func (r *SvcRunner) Supervised() bool {

--- a/daemon/svc_runner_windows.go
+++ b/daemon/svc_runner_windows.go
@@ -266,13 +266,21 @@ func (r *SvcRunner) Restart() error {
 
 func (r *SvcRunner) restart() error {
 	if r.Running() {
-		r.stop()
-		for timeout := 0; r.Running() || timeout >= 5; timeout++ {
+		if err := r.stop(); err != nil {
+			log.Errorf("[%s] Failed to stop: %v", r.Name(), err)
+		}
+		for timeout := 0; r.Running() && timeout < 5; timeout++ {
 			log.Debugf("[%s] waiting for process to finish...", r.Name())
 			time.Sleep(1 * time.Second)
 		}
+		if r.Running() {
+			log.Warnf("[%s] Timeout waiting for process to stop, proceeding with start", r.Name())
+		}
 	}
-	r.start()
+	if err := r.start(); err != nil {
+		log.Errorf("[%s] Failed to start after restart: %v", r.Name(), err)
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fix an infinite loop in `SvcRunner.restart()` on Windows that has been present since December 2018 (commit acfcc9b8), and add a shutdown timeout to `distributor.Stop()` to prevent process overlap during sidecar restarts.
                                                                                                                              
## Problem                                             

### Infinite loop in `restart()`

The wait loop condition in `SvcRunner.restart()` is inverted:                                                               
  
  ```go                                                                                                                       
  for timeout := 0; r.Running() || timeout >= 5; timeout++
  ```                                                                                                                         
  
Once `timeout` reaches 5, the `timeout >= 5` side of the `||` is always true, making the loop condition always true regardless of service state. The loop never exits.     
                                                                                                                              
This permanently blocks the `signalProcessor` goroutine. Since `Restart()` and `Shutdown()` both send to an unbuffered channel that the signal processor reads from, all subsequent restart and shutdown signals block forever. The sidecar's entire polling loop stalls on the next `runner.Restart()` call, preventing all further configuration updates and status reporting. The server marks the sidecar as inactive.   

The bug was dormant because Beats 7.x stopped quickly enough to never trigger it. It became user-visible after sidecar 1.5.0 shipped with Beats 8.x, which can take longer to shut down. Customers are reporting failing config updates and behavior consistent with this bug after upgrading.
                                                                                                                              
### Missing error handling in `restart()`                                                                                   
  
Both `stop()` and `start()` return errors that `restart()` silently discards. If `start()` fails after a stop (e.g., the service is still in `StopPending`), the collector is left dead with no log output explaining why.
                                                                                                                              
### No shutdown timeout in `distributor.Stop()`        

When the sidecar shuts down, `distributor.Stop()` waits for runners to finish using `runner.Running()`. On Windows, `SvcRunner.Running()` checks `status.State == svc.Running`, which returns `false` for `StopPending`. The old sidecar process exits while the collector service is still shutting down, leaving log files locked and the service in a transitional state.
                                                         
When a new sidecar process starts, it encounters a half-dead collector service. The subsequent `restart()` attempt is likely to hit the infinite loop bug (the service is slow to stop because it's already stopping), wedging the new sidecar as well. Additionally, the wait loop had no timeout, so a stuck runner could prevent the sidecar from ever shutting down.            
  
## Failure scenarios addressed                                                                                              
                                                         
  **Config change never applied:** User changes a configuration in the Graylog UI. The sidecar detects the change, writes the new config file, and calls `Restart()`. If the collector service takes longer than ~15 seconds to stop (10s `stopService` timeout + 5s wait loop), the infinite loop triggers. The signal processor is permanently blocked, the polling loop stalls,  and no further config changes are ever applied.        

**Sidecar restart causes collector to die:** User restarts the sidecar process. The old sidecar's `distributor.Stop()` sends a stop signal to the collector but exits before the collector has fully stopped (`StopPending` vs `Stopped`). The new sidecar starts and tries to restart the collector, but the service is still shutting down. This either triggers the infinite loop (service slow to stop) or causes `start()` to fail silently (service still in `StopPending`), leaving the collector dead with the correct config on disk but no process running it.

**Repeated wedging across sidecar restarts:** An admin notices the sidecar is inactive and restarts it. The new sidecar encounters the same half-dead collector from the previous attempt and wedges again. The only recovery is to manually stop the collector service via the Windows Service Manager before restarting the sidecar.                                        
                                                         
## How tested                                                                                                               
                                                        
  - Verified by code inspection (the loop condition fix is a boolean logic correction)                                        
  - The `distributor.go` change is cross-platform; `svc_runner_windows.go` is Windows-only (build-constrained)
  - No existing unit tests for the `daemon` package (code is tightly coupled to the Windows Service Control Manager)          
  - Manual testing: deploy updated sidecar to a Windows host, change a collector configuration in the Graylog UI, observe that the new configuration is applied and persists across polling intervals                                                     
                                                                                                                              
  Fixes: Graylog2/graylog-plugin-enterprise#14264        

