### PR TITLE
Backport 1.5: Register graylog-sidecar as Windows service via MSI installer (#537)

### DIFF
--- a/dist/msi-package.wxs
+++ b/dist/msi-package.wxs
@@ -45,6 +45,21 @@
               <File Id='SidecarLicense'
                 Name='LICENSE'
                 Source='$(var.LicensePath)' />
+              <ServiceInstall
+                Id='SidecarServiceInstall'
+                Name='graylog-sidecar'
+                DisplayName='Graylog Sidecar'
+                Description='Wrapper service for Graylog controlled collector'
+                Type='ownProcess'
+                Start='auto'
+                ErrorControl='normal'
+                Account='LocalSystem' />
+              <ServiceControl
+                Id='SidecarServiceControl'
+                Name='graylog-sidecar'
+                Stop='both'
+                Remove='uninstall'
+                Wait='yes' />
             </Component>
             <Component Id='SidecarConfig' Guid='FECCBAFB-C7A7-4570-9A28-172FDB5B0DE1'>
               <!-- We don't install a sidecar.yml file so we don't remove the file when uninstalling the package. -->


### PR DESCRIPTION
* Register graylog-sidecar Windows service via MSI installer

Add ServiceInstall and ServiceControl elements to the WiX package so the service is registered automatically on install, removing the need to manually run `graylog-sidecar.exe -service install` post-install.



* Don't auto-start service on install, require manual start after configuring sidecar.yml

/nocl build changes

---------



(cherry picked from commit 0d67f43ad94dad7e3402171dc15b6aa4e6aaa7c0)

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

