### PR TITLE
Backport 1.5: Split NSIS install procedure to allow signing of uninstaller.exe (#555)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,12 +178,15 @@ FORCE:
 .PHONY: package-all
 package-all: prepare-package
 package-all: package-linux-armv7 package-linux-arm64 package-linux-amd64 package-linux32
-package-all: package-windows-exe-amd64 package-windows-msi-amd64
+package-all: package-windows-msi-amd64 # no longer builds the exe target, would make it awkward in CI
 package-all: package-tar
 
 .PHONY: prepare-package
-prepare-package: branding-files
+prepare-package: branding-files dist/collectors/.fetched
+
+dist/collectors/.fetched:
 	dist/fetch_collectors.sh
+	@touch $@
 
 # Export branding variables for FPM recipes
 FPM_BRAND_ENV = \
@@ -231,25 +234,57 @@ package-linux32: ## Create Linux i386 system package
 	$(FPM_BRAND_ENV) fpm-cook -t deb package dist/recipe32.rb
 	$(FPM_BRAND_ENV) fpm-cook -t rpm package dist/recipe32.rb
 
-.PHONY: package-windows-exe-amd64
-package-windows-exe-amd64: prepare-package ## Create Windows installer
-	@mkdir -p dist/pkg
-	makensis -DVERSION=$(COLLECTOR_VERSION) \
-		-DVERSION_SUFFIX=$(COLLECTOR_VERSION_SUFFIX) \
-		-DREVISION=$(COLLECTOR_REVISION) \
-		-DBRAND_VENDOR_NAME="$(BRAND_VENDOR_NAME)" \
-		-DBRAND_VENDOR_DISPLAY="$(BRAND_VENDOR_DISPLAY)" \
-		-DBRAND_PRODUCT_NAME="$(BRAND_PRODUCT_NAME)" \
-		-DBRAND_PRODUCT_DISPLAY="$(BRAND_PRODUCT_DISPLAY)" \
-		-DBRAND_PRODUCT_LOWER="$(BRAND_PRODUCT_LOWER)" \
-		-DBRAND_PRODUCT_LOWER_UNDERSCORE="$(BRAND_PRODUCT_LOWER_UNDERSCORE)" \
-		-DBRAND_HOMEPAGE_URL="$(BRAND_HOMEPAGE_URL)" \
-		-DBRAND_ICON_FILE="$(BRAND_ICON_FILE_ABS)" \
-		-DBRAND_REGISTRY_KEY="$(BRAND_REGISTRY_KEY)" \
-		-DBRAND_WIN_VENDOR_DIR="$(BRAND_WIN_VENDOR_DIR)" \
-		-DBRAND_WIN_PRODUCT_DIR="$(BRAND_WIN_PRODUCT_DIR)" \
-		dist/recipe.nsi
+# Defines passed to makensis. Shared by both passes of the installer build (see
+# prepare-package-windows-exe-amd64) so the inner and outer invocations stay in sync.
+NSIS_DEFINES = -DVERSION=$(COLLECTOR_VERSION) \
+	-DVERSION_SUFFIX=$(COLLECTOR_VERSION_SUFFIX) \
+	-DREVISION=$(COLLECTOR_REVISION) \
+	-DBRAND_VENDOR_NAME="$(BRAND_VENDOR_NAME)" \
+	-DBRAND_VENDOR_DISPLAY="$(BRAND_VENDOR_DISPLAY)" \
+	-DBRAND_PRODUCT_NAME="$(BRAND_PRODUCT_NAME)" \
+	-DBRAND_PRODUCT_DISPLAY="$(BRAND_PRODUCT_DISPLAY)" \
+	-DBRAND_PRODUCT_LOWER="$(BRAND_PRODUCT_LOWER)" \
+	-DBRAND_PRODUCT_LOWER_UNDERSCORE="$(BRAND_PRODUCT_LOWER_UNDERSCORE)" \
+	-DBRAND_HOMEPAGE_URL="$(BRAND_HOMEPAGE_URL)" \
+	-DBRAND_ICON_FILE="$(BRAND_ICON_FILE_ABS)" \
+	-DBRAND_REGISTRY_KEY="$(BRAND_REGISTRY_KEY)" \
+	-DBRAND_WIN_VENDOR_DIR="$(BRAND_WIN_VENDOR_DIR)" \
+	-DBRAND_WIN_PRODUCT_DIR="$(BRAND_WIN_PRODUCT_DIR)"
 
+
+# Windows exe packaging without codesigning the uninstall.exe
+.PHONY: package-windows-exe-amd64
+package-windows-exe-amd64: prepare-package-windows-exe-amd64 finalize-package-windows-exe-amd64
+
+.PHONY: prepare-package-windows-exe-amd64
+prepare-package-windows-exe-amd64: prepare-package ## Create Windows installer
+	@mkdir -p dist/pkg
+	# Two-pass build so the bundled uninstaller can be code-signed. NSIS only
+	# materializes the uninstaller by *running* an installer, so we:
+	#   1. Build a throwaway "inner" installer that just emits the uninstaller.
+	#   2. Run it (under Wine on Linux) to write dist/pkg/uninstall.exe.
+	#   3. Sign that uninstaller.
+	#   4. Build the real installer, which bundles the signed uninstall.exe.
+	# NOTE: because of step 3, this target now needs the graylog/internal-codesigntool
+	# image and Wine available, not just makensis. On a headless CI host Wine may
+	# need an X server (e.g. wrap the run in xvfb-run).
+	makensis $(NSIS_DEFINES) -DINNER dist/recipe.nsi
+	# The inner installer quits in .onInit with exit code 2 by design; verify the
+	# artifact rather than the exit code, so Wine quirks don't fail the build.
+	xvfb-run wine dist/pkg/tempinstaller.exe /S || true
+	test -f dist/pkg/uninstall.exe
+
+# This needs to run in the codesign container, so we don't have a target running the entire package anymore
+.PHONY: sign-nsis-uninstall-exe-amd64
+sign-nsis-uninstall-exe-amd64:
+	test -f dist/pkg/uninstall.exe
+	codesigntool sign dist/pkg/uninstall.exe
+
+.PHONY: finalize-package-windows-exe-amd64
+finalize-package-windows-exe-amd64:
+	test -f dist/pkg/uninstall.exe
+	makensis $(NSIS_DEFINES) dist/recipe.nsi
+	rm -f dist/pkg/tempinstaller.exe
 
 .PHONY: package-windows-msi-amd64
 package-windows-msi-amd64: prepare-package ## Create Windows MSI package (requires packages: msitools, wixl)

--- a/dist/recipe.nsi
+++ b/dist/recipe.nsi
@@ -29,7 +29,15 @@
 ;General
 
   !searchreplace SUFFIX '${VERSION_SUFFIX}' "-" "."
+!ifdef INNER
+  ; Inner build pass: a throwaway installer whose only purpose is to emit a
+  ; standalone uninstaller (see Function .onInit) so it can be code-signed before
+  ; the real installer is built. Driven by the two-pass logic in the Makefile.
+  OutFile "pkg/tempinstaller.exe"
+  SetCompress off
+!else
   OutFile "pkg/${BRAND_PRODUCT_LOWER_UNDERSCORE}_installer_${VERSION}-${REVISION}${SUFFIX}.exe"
+!endif
   RequestExecutionLevel admin ;Require admin rights
   ShowInstDetails "show"
   ShowUninstDetails "show"
@@ -185,7 +193,14 @@ Section "Install"
     ${LogWrite} "Restarting existing Sidecar Service: [exit $0] Stdout: $1"
   ${EndIf}
 
-  WriteUninstaller "$INSTDIR\uninstall.exe"
+  ; The uninstaller is generated and signed during the inner build pass (see the
+  ; INNER block at the top of this file and the Makefile), then bundled here as a
+  ; signed file instead of being generated with WriteUninstaller. The inner pass
+  ; never reaches this section (it quits in .onInit), and dist/pkg/uninstall.exe
+  ; does not exist yet while the inner installer compiles, so guard it out there.
+!ifndef INNER
+  File "/oname=uninstall.exe" "pkg/uninstall.exe"
+!endif
 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${BRAND_REGISTRY_KEY}" \
                  "DisplayName" "${BRAND_PRODUCT_DISPLAY}"
@@ -329,6 +344,15 @@ SectionEnd
 ;Functions
 
 Function .onInit
+!ifdef INNER
+  ; Inner build pass: emit the uninstaller next to this temp installer (which the
+  ; Makefile placed in dist/pkg/) and quit immediately, before any UI or install
+  ; logic runs. SetErrorLevel 2 follows the NSIS convention for "intentional quit".
+  SetSilent silent
+  WriteUninstaller "$EXEDIR\uninstall.exe"
+  SetErrorLevel 2
+  Quit
+!endif
   !insertmacro Check_X64
 
   FileOpen $LogFile "$INSTDIR\installerlog.txt" w

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -91,6 +91,7 @@ pipeline
               image 'graylog/internal-sidecar-packaging:latest'
               args '-u jenkins:jenkins'
               registryCredentialsId 'docker-hub'
+              alwaysPull true
               reuseNode true
             }
           }
@@ -98,6 +99,73 @@ pipeline
           steps
           {
             sh 'make package-all'
+            // Build the Windows installer up to the point where the unsigned
+            // uninstall.exe has been emitted (inner NSIS pass + Wine run). The
+            // uninstaller is signed in the next stage (codesign image), then
+            // 'Finalize Windows Installer' bundles it and builds the real
+            // installer back in this packaging image.
+            sh 'make prepare-package-windows-exe-amd64'
+          }
+        }
+
+        // The uninstaller must be signed *before* the real installer is built,
+        // because the installer embeds it (NSIS can't sign a file it generates
+        // at runtime). We sign it here, in the codesign image, in between the
+        // prepare and finalize packaging steps. Skipped on non-tag builds, which
+        // therefore ship an unsigned uninstaller (same as before this change).
+        stage('Sign Windows Uninstaller')
+        {
+          when
+          {
+            buildingTag()
+          }
+
+          agent
+          {
+            docker
+            {
+              image 'graylog/internal-codesigntool:latest'
+              args '-u jenkins:jenkins'
+              registryCredentialsId 'docker-hub'
+              alwaysPull false // Already pulled in the 'Sign Windows Binaries' stage
+              reuseNode true
+            }
+          }
+
+          environment
+          {
+            CODESIGN_USER = credentials('codesign-user')
+            CODESIGN_PASS = credentials('codesign-pass')
+            CODESIGN_TOTP_SECRET = credentials('codesign-totp-secret')
+            CODESIGN_CREDENTIAL_ID = credentials('codesign-credential-id')
+          }
+
+          steps
+          {
+            sh 'make sign-nsis-uninstall-exe-amd64'
+          }
+        }
+
+        // Build the real installer back in the packaging image. It bundles the
+        // uninstall.exe produced above (signed on tag builds, unsigned otherwise).
+        // Runs on every build so PRs still get a complete installer artifact.
+        stage('Finalize Windows Installer')
+        {
+          agent
+          {
+            docker
+            {
+              image 'graylog/internal-sidecar-packaging:latest'
+              args '-u jenkins:jenkins'
+              registryCredentialsId 'docker-hub'
+              alwaysPull false // Already pulled in the 'Package' stage
+              reuseNode true
+            }
+          }
+
+          steps
+          {
+            sh 'make finalize-package-windows-exe-amd64'
           }
         }
 


### PR DESCRIPTION
* Split NSIS install procedure to allow signing of uninstaller.exe

* make sure to pull the packaging docker image

* refactor exe installer into 3 steps: prepare/uninstall.exe generation, optional sign, package

we no longer build the exe-installer in package-all because the CI pipeline would get complicated instead it's built in a separate step in jenkins, locally it can easily be build with the standalone target

* add guard to prevent refetches of collectors

---------

/nocl build changes

(cherry picked from commit c8dacca099602f7f691f9a28e3e414e0f1ad08aa)

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

