### PR TITLE
Backport 1.5: Brand the MSI Windows-service name/display/description

### DIFF
--- a/dist/msi-package.wxs
+++ b/dist/msi-package.wxs
@@ -47,16 +47,16 @@
                 Source='$(var.LicensePath)' />
               <ServiceInstall
                 Id='SidecarServiceInstall'
-                Name='graylog-sidecar'
-                DisplayName='Graylog Sidecar'
-                Description='Wrapper service for Graylog controlled collector'
+                Name='$(var.BrandProductLower)'
+                DisplayName='$(var.BrandProductDisplay)'
+                Description='Wrapper service for $(var.BrandVendorName) controlled collector'
                 Type='ownProcess'
                 Start='auto'
                 ErrorControl='normal'
                 Account='LocalSystem' />
               <ServiceControl
                 Id='SidecarServiceControl'
-                Name='graylog-sidecar'
+                Name='$(var.BrandProductLower)'
                 Stop='both'
                 Remove='uninstall'
                 Wait='yes' />


### PR DESCRIPTION
use brand variables instead of hardcoded strings in service install/remove (#556)

/nocl build

(cherry picked from commit 5fb7cff449e2e18a4ec9b838b573813de43d0ec8)

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

